### PR TITLE
Add app badge service to sync notification count

### DIFF
--- a/picnic_app/lib/app.dart
+++ b/picnic_app/lib/app.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:picnic_app/presentation/screens/portal.dart';
 import 'package:picnic_lib/core/utils/app_builder.dart';
 import 'package:picnic_lib/core/utils/app_initializer.dart';
+import 'package:picnic_lib/core/services/app_badge_service.dart';
 import 'package:picnic_lib/core/utils/app_lifecycle_initializer.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/core/utils/route_manager.dart';
@@ -294,6 +295,8 @@ class _AppState extends ConsumerState<App> with WidgetsBindingObserver {
       case AppLifecycleState.resumed:
         // 앱이 포그라운드로 돌아올 때
         logger.i('앱이 포그라운드로 복귀');
+        // Sync app badge with unread notifications count
+        AppBadgeService.syncBadgeWithUnreadCount();
         break;
       case AppLifecycleState.inactive:
         // 앱이 비활성화될 때

--- a/picnic_lib/lib/core/services/app_badge_service.dart
+++ b/picnic_lib/lib/core/services/app_badge_service.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_app_badger/flutter_app_badger.dart';
+import 'package:picnic_lib/core/utils/logger.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Service to manage app icon badge count
+/// Syncs the badge number with unread notifications count
+class AppBadgeService {
+  static bool _isSupported = false;
+  static bool _checkedSupport = false;
+
+  /// Check if app badges are supported on this device
+  static Future<bool> isSupported() async {
+    if (_checkedSupport) return _isSupported;
+
+    if (kIsWeb) {
+      _checkedSupport = true;
+      _isSupported = false;
+      return false;
+    }
+
+    try {
+      _isSupported = await FlutterAppBadger.isAppBadgeSupported();
+      _checkedSupport = true;
+      logger.i('App badge supported: $_isSupported');
+      return _isSupported;
+    } catch (e) {
+      logger.w('Failed to check badge support: $e');
+      _checkedSupport = true;
+      _isSupported = false;
+      return false;
+    }
+  }
+
+  /// Update badge count to match unread notifications
+  static Future<void> syncBadgeWithUnreadCount() async {
+    if (kIsWeb) return;
+    if (!Platform.isIOS && !Platform.isAndroid) return;
+
+    try {
+      final supported = await isSupported();
+      if (!supported) return;
+
+      final count = await _getUnreadCount();
+      await _updateBadge(count);
+    } catch (e, s) {
+      logger.e('Failed to sync badge', error: e, stackTrace: s);
+    }
+  }
+
+  /// Set badge to a specific count
+  static Future<void> setBadgeCount(int count) async {
+    if (kIsWeb) return;
+    if (!Platform.isIOS && !Platform.isAndroid) return;
+
+    try {
+      final supported = await isSupported();
+      if (!supported) return;
+
+      await _updateBadge(count);
+    } catch (e, s) {
+      logger.e('Failed to set badge count', error: e, stackTrace: s);
+    }
+  }
+
+  /// Remove badge (set count to 0)
+  static Future<void> removeBadge() async {
+    if (kIsWeb) return;
+    if (!Platform.isIOS && !Platform.isAndroid) return;
+
+    try {
+      final supported = await isSupported();
+      if (!supported) return;
+
+      await FlutterAppBadger.removeBadge();
+      logger.i('App badge removed');
+    } catch (e, s) {
+      logger.e('Failed to remove badge', error: e, stackTrace: s);
+    }
+  }
+
+  /// Get unread notifications count from database
+  static Future<int> _getUnreadCount() async {
+    try {
+      final client = Supabase.instance.client;
+      final user = client.auth.currentUser;
+      if (user == null) return 0;
+
+      final List<dynamic> rows = await client
+          .from('user_notifications')
+          .select('id')
+          .eq('user_id', user.id)
+          .eq('is_read', false)
+          .limit(200);
+
+      return rows.length;
+    } catch (e) {
+      logger.w('Failed to get unread count for badge: $e');
+      return 0;
+    }
+  }
+
+  /// Update badge with count
+  static Future<void> _updateBadge(int count) async {
+    try {
+      if (count <= 0) {
+        await FlutterAppBadger.removeBadge();
+        logger.i('App badge removed (count: 0)');
+      } else {
+        await FlutterAppBadger.updateBadgeCount(count);
+        logger.i('App badge updated: $count');
+      }
+    } catch (e) {
+      logger.w('Failed to update badge: $e');
+    }
+  }
+}

--- a/picnic_lib/lib/core/services/notification_inbox_service.dart
+++ b/picnic_lib/lib/core/services/notification_inbox_service.dart
@@ -1,4 +1,5 @@
 import 'package:picnic_lib/core/utils/logger.dart';
+import 'package:picnic_lib/core/services/app_badge_service.dart';
 import 'package:picnic_lib/supabase_options.dart';
 import 'package:picnic_lib/data/models/user_notification.dart';
 
@@ -72,6 +73,9 @@ class NotificationInboxService {
             'read_at': DateTime.now().toIso8601String(),
           })
           .eq('id', id);
+      // Sync app badge with updated unread count
+      // ignore: unawaited_futures
+      AppBadgeService.syncBadgeWithUnreadCount();
       return true;
     } catch (e, s) {
       logger.e('mark read failed', error: e, stackTrace: s);
@@ -91,6 +95,9 @@ class NotificationInboxService {
           })
           .eq('user_id', user.id)
           .eq('is_read', false);
+      // Clear app badge when all notifications are marked as read
+      // ignore: unawaited_futures
+      AppBadgeService.removeBadge();
       return true;
     } catch (e, s) {
       logger.e('mark all read failed', error: e, stackTrace: s);

--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -15,6 +15,7 @@ import 'package:picnic_lib/core/services/update_service.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/core/utils/privacy_consent_manager.dart';
 import 'package:picnic_lib/core/services/push_token_service.dart';
+import 'package:picnic_lib/core/services/app_badge_service.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:picnic_lib/core/utils/token_refresh_manager.dart';
 import 'package:picnic_lib/core/utils/ui.dart';
@@ -399,6 +400,9 @@ class AppInitializer {
             });
           },
         );
+        // Sync app badge with unread notifications count
+        // ignore: unawaited_futures
+        AppBadgeService.syncBadgeWithUnreadCount();
         if (!context.mounted) return;
         await _loadProducts(ref);
 

--- a/picnic_lib/pubspec.yaml
+++ b/picnic_lib/pubspec.yaml
@@ -104,6 +104,7 @@ dependencies:
   flutter_branch_sdk: ^8.3.2
   shorebird_code_push: ^2.0.3
   restart_app: ^1.2.1
+  flutter_app_badger: ^1.5.0
   googleapis: ^14.0.0
   googleapis_auth: ^2.0.0
   json_annotation: ^4.9.0

--- a/ttja_app/lib/app.dart
+++ b/ttja_app/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:picnic_lib/core/utils/app_builder.dart';
 import 'package:picnic_lib/core/utils/app_initializer.dart';
+import 'package:picnic_lib/core/services/app_badge_service.dart';
 import 'package:picnic_lib/core/utils/app_lifecycle_initializer.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/core/utils/language_initializer.dart';
@@ -209,6 +210,8 @@ class _AppState extends ConsumerState<App> with WidgetsBindingObserver {
     switch (state) {
       case AppLifecycleState.resumed:
         // 앱이 포그라운드로 돌아올 때 필요한 작업
+        // Sync app badge with unread notifications count
+        AppBadgeService.syncBadgeWithUnreadCount();
         break;
       case AppLifecycleState.inactive:
         // 앱이 비활성화될 때 필요한 작업


### PR DESCRIPTION
## Summary
Implement app icon badge functionality to display unread notification counts on iOS and Android devices. The badge automatically syncs when the app resumes from background and updates whenever notifications are marked as read.

## Key Changes
- **New `AppBadgeService`**: Created a platform-aware service that manages app icon badges
  - Checks device support for badges (iOS/Android only, not web)
  - Syncs badge count with unread notifications from database
  - Provides methods to set, update, and remove badges
  - Includes proper error handling and logging

- **Integration points**:
  - App lifecycle: Badge syncs when app returns to foreground (resumed state)
  - Notification inbox: Badge updates when notifications are marked as read or all marked as read
  - App initialization: Badge syncs after user authentication completes

- **Dependencies**: Added `flutter_app_badger: ^1.5.0` to pubspec.yaml

## Implementation Details
- Badge count is fetched from `user_notifications` table, counting unread entries
- Gracefully handles unsupported devices and web platforms
- Uses `unawaited_futures` for non-blocking badge updates in notification operations
- Caches badge support check to avoid repeated platform calls
- Comprehensive error handling with appropriate logging levels

https://claude.ai/code/session_01Uz9uHo9ksmhGed3qiPqjnV