### PR TITLE
chore(deps): sentry_flutter ^9.19.0 으로 bump (Android JNI segfault 완화)

### DIFF
--- a/picnic_app/pubspec.lock
+++ b/picnic_app/pubspec.lock
@@ -2159,18 +2159,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "605ad1f6f1ae5b72018cbe8fc20f490fa3bd53e58882e5579566776030d8c8c1"
+      sha256: "1f78300740739ff4b4920802687879231554350eab73eb229778f463aabda440"
       url: "https://pub.dev"
     source: hosted
-    version: "9.14.0"
+    version: "9.19.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "7fd0fb80050c1f6a77ae185bda997a76d384326d6777cf5137a6c38952c4ac7d"
+      sha256: "168bbb120f7684dee6c0e100817f56ee1925bc2eb7fa55a71253337640c7e241"
       url: "https://pub.dev"
     source: hosted
-    version: "9.14.0"
+    version: "9.19.0"
   share_plus:
     dependency: transitive
     description:

--- a/picnic_app/pubspec.yaml
+++ b/picnic_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
     another_flutter_splash_screen: ^1.2.1
     device_info_plus: ^12.3.0
     firebase_core: ^4.2.1
-    sentry_flutter: ^9.0.0
+    sentry_flutter: ^9.19.0
 
     firebase_analytics: ^12.0.4
     flutter_secure_storage: ^9.2.3

--- a/picnic_lib/pubspec.yaml
+++ b/picnic_lib/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_gen: ^5.3.1
   shimmer: ^3.0.0
-  sentry_flutter: ^9.0.0
+  sentry_flutter: ^9.19.0
   universal_platform: ^1.1.0
   url_launcher: ^6.3.1
   flutter_cache_manager: ^3.4.1

--- a/ttja_app/pubspec.lock
+++ b/ttja_app/pubspec.lock
@@ -1613,14 +1613,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "64e35e1e2e79da4e83f2ace3bf4e5437cef523f46c7db2eba9a1419c49573790"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -2016,18 +2008,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "10a0bc25f5f21468e3beeae44e561825aaa02cdc6829438e73b9b64658ff88d9"
+      sha256: "1f78300740739ff4b4920802687879231554350eab73eb229778f463aabda440"
       url: "https://pub.dev"
     source: hosted
-    version: "9.8.0"
+    version: "9.19.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: aafbf41c63c98a30b17bdbf3313424d5102db62b08735c44bff810f277e786a5
+      sha256: "168bbb120f7684dee6c0e100817f56ee1925bc2eb7fa55a71253337640c7e241"
       url: "https://pub.dev"
     source: hosted
-    version: "9.8.0"
+    version: "9.19.0"
   share_plus:
     dependency: transitive
     description:

--- a/ttja_app/pubspec.yaml
+++ b/ttja_app/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     another_flutter_splash_screen: ^1.2.1
     device_info_plus: ^12.3.0
     firebase_core: ^4.2.1
-    sentry_flutter: ^9.8.0
+    sentry_flutter: ^9.19.0
     firebase_analytics: ^12.0.4
     flutter_secure_storage: ^9.2.3
     timezone: ^0.10.0


### PR DESCRIPTION
## Summary

Sentry **PICNIC-APP-4QT** (508 events / 192 users, fatal SIGSEGV in `globalEnv_CallObjectMethod`) 완화 시도. picnic 트리에서 `jni` native bridge 를 참조하는 패키지는 `sentry_flutter` 단독이며, 이는 Sentry SDK 자신의 native crash handler 가 segfault 를 일으키는 패턴.

`9.14.0 → 9.19.0` 사이 native 스택 안정화 변경:
- Native SDK `0.12.8 → 0.13.7`
- Android SDK `8.33.0 → 8.39.1`

## Changes

- `picnic_lib/pubspec.yaml`: `sentry_flutter: ^9.0.0 → ^9.19.0`
- `picnic_app/pubspec.yaml`: `sentry_flutter: ^9.0.0 → ^9.19.0` + lock 갱신
- `ttja_app/pubspec.yaml`: `sentry_flutter: ^9.8.0 → ^9.19.0` + lock 갱신

## Compatibility

사용 중인 옵션은 모두 호환:
- `enableNativeCrashHandling`, `enableAutoNativeBreadcrumbs`, `attachStacktrace`, `enableAutoSessionTracking`, `beforeSend`, `maxBreadcrumbs`
- 9.19.0 에서 추가된 `traceLifecycle = stream` 은 기본값 변경 없음 → 동작 변화 없음
- `enableNewTraceOnNavigation` 의 default 가 `false` 로 변경됐지만 picnic 은 `SentryNavigatorObserver` 를 사용하지 않으므로 영향 없음

## Test plan

- [x] `flutter pub upgrade sentry_flutter` 정상 (3개 패키지)
- [x] `flutter test test/core/utils/retry_http_client_test.dart test/core/utils/app_initializer_test.dart` — 87/87 passed
- [ ] 머지 후 다음 릴리스 (1.2.24+) 빌드 → 24~72h prod 모니터링으로 PICNIC-APP-4QT 신규 이벤트 감소 추이 확인
- [ ] 효과 없을 시 `enableNativeCrashHandling = false` 우회 검토 (다른 native 크래시 가시성 trade-off 동반)

## Why this approach

- Native segfault 는 단위 테스트로 검증 불가 → 가장 안전한 출발점은 upstream 의 native 스택 업데이트
- 5 minor 버전 (9.15~9.19) 에 걸쳐 누적된 Native/Android SDK 업데이트는 일반적으로 JNI 호환성 개선을 포함
- 효과 없을 경우의 fallback (native crash handler off) 도 명확함

🤖 Generated with [Claude Code](https://claude.com/claude-code)