### PR TITLE
fix(sentry): beforeSend 필터의 production-leak 갭 3종 보강

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -28,6 +28,8 @@ class AppInitializerHelper {
       'NetworkError',
       'ClientException',
       'OSError',
+      'HttpException',
+      'SocketException',
       'AuthRetryableFetchException',
     };
     if (networkNoiseTypes.contains(exceptionType)) {
@@ -51,9 +53,14 @@ class AppInitializerHelper {
       return true;
     }
 
-    // Edge Function 502 Bad Gateway
+    // Edge Function transient gateway errors (502/503/504)
+    // 503 SUPABASE_EDGE_RUNTIME_ERROR is a Supabase platform-side outage
+    // signal, not a picnic bug (PICNIC-APP-4ZY/4ZX/4EN).
     if (exceptionType == 'FunctionException' &&
-        exceptionValue.contains('502')) {
+        (exceptionValue.contains('502') ||
+            exceptionValue.contains('503') ||
+            exceptionValue.contains('504') ||
+            exceptionValue.contains('SUPABASE_EDGE_RUNTIME_ERROR'))) {
       return true;
     }
 
@@ -73,6 +80,18 @@ class AppInitializerHelper {
     // JWT expired (PICNIC-APP-47R)
     if (exceptionType == 'PostgrestException' &&
         exceptionValue.contains('JWT expired')) {
+      return true;
+    }
+
+    // Postgrest wrapping a user-side network drop (PICNIC-APP-47).
+    // The wire-level error is rendered into the message, not the type, so
+    // exact-type filters above miss it. Drop these as user-environment noise.
+    if (exceptionType == 'PostgrestException' &&
+        (exceptionValue.contains('NetworkError') ||
+            exceptionValue.contains('SocketException') ||
+            exceptionValue.contains('Failed host lookup') ||
+            exceptionValue.contains('Connection closed') ||
+            exceptionValue.contains('Connection reset'))) {
       return true;
     }
 

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -247,6 +247,149 @@ void main() {
         );
       });
 
+      // -------- Coverage gap fixes (production-leak issues on 1.2.27) --------
+
+      test('filters HttpException as network noise (PICNIC-APP-49W)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'HttpException',
+            exceptionValue: 'HttpException: Invalid statusCode: 502, '
+                'uri = https://supabase.co/storage/...',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters SocketException as network noise', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'SocketException',
+            exceptionValue: 'Failed host lookup',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException with 503 (PICNIC-APP-4ZY/4ZX/4EN)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 503, details: '
+                '{code: SUPABASE_EDGE_RUNTIME_ERROR, '
+                'message: Service is temporarily unavailable})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException with 504 gateway timeout', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'Edge Function returned 504',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException with SUPABASE_EDGE_RUNTIME_ERROR code',
+          () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'Error: SUPABASE_EDGE_RUNTIME_ERROR',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters PostgrestException wrapping NetworkError (PICNIC-APP-47)',
+          () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'PostgrestException',
+            exceptionValue: 'PostgrestException(message: '
+                '{"error": "NetworkError: Network connection error: '
+                'ClientException with SocketException: Failed host lookup"})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters PostgrestException wrapping SocketException', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'PostgrestException',
+            exceptionValue: 'SocketException: Software caused connection abort',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters PostgrestException with Failed host lookup', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'PostgrestException',
+            exceptionValue: 'Failed host lookup: api.supabase.co',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters PostgrestException with Connection closed', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'PostgrestException',
+            exceptionValue: 'Connection closed before full header was received',
+          ),
+          isTrue,
+        );
+      });
+
+      test('still does not filter actionable PostgrestException messages', () {
+        // Real bugs (RLS misconfig in code, missing column) should still
+        // surface. Only network-environment noise is dropped.
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'PostgrestException',
+            exceptionValue: 'column "user_id" does not exist',
+          ),
+          isFalse,
+        );
+      });
+
+      test('does not filter FunctionException with 500 (real server bug)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'Internal Server Error 500',
+          ),
+          isFalse,
+        );
+      });
+
       test('filters when both Sentry disabled and debug mode', () {
         expect(
           AppInitializerHelper.shouldFilterSentryEvent(


### PR DESCRIPTION
## Summary

릴리스 1.2.27(현 prod) 에서도 여전히 Sentry 로 새어나오는 노이즈 이벤트 약 **22k+ 건** 차단. 모두 사용자 환경/백엔드 측 transient 이슈로, picnic 코드 결함이 아니라 Sentry 신호로서의 가치가 없는 항목.

## Identified gaps (1.2.27 production)

| Sentry Issue | 패턴 | 누락된 필터 | Impact |
|---|---|---|---|
| **PICNIC-APP-49W** | `HttpException: Invalid statusCode: 502, uri = supabase storage` | `HttpException` 타입이 networkNoiseTypes 에 미포함 | 2,379 events / 28 users |
| **PICNIC-APP-4ZY/4ZX/4EN** | `FunctionException(status: 503, code: SUPABASE_EDGE_RUNTIME_ERROR)` | 502 만 필터, 503/504 누락 | 3,400+ events / 200+ users, **어제도 발생** |
| **PICNIC-APP-47** | `PostgrestException(message: "NetworkError: ... SocketException: Failed host lookup")` | DOCTYPE/502/JWT 만 필터, 네트워크 단절 메시지 누락 | 17,136 events / 569 users, **어제도 발생** |

## Changes

`picnic_lib/lib/core/utils/app_initializer_helper.dart`:
- `networkNoiseTypes` 에 `HttpException`, `SocketException` 추가
- `FunctionException` 필터를 502 → `502/503/504/SUPABASE_EDGE_RUNTIME_ERROR` 로 확장
- `PostgrestException` network-wrap 필터 신설 (NetworkError / SocketException / Failed host lookup / Connection closed/reset)

## Safety net

실제 actionable 한 PostgrestException 메시지(예: `column "user_id" does not exist`) 와 `FunctionException(status: 500)` 는 **계속 Sentry 로 보고됨** — 신호 손실 없음. 테스트로 명시적 검증.

## Test plan

- [x] `flutter test test/core/utils/app_initializer_helper_test.dart` — 79/79 passed (기존 68 + 신규 11)
- [x] `flutter test test/core/utils/app_initializer_test.dart` — 47/47 passed (인라인 중복 로직 미수정 — 추후 정리 가능)
- [ ] 머지 후 다음 릴리스 빌드 → 24h Sentry 이벤트 그래프에서 위 3개 issue 신규 이벤트 0 으로 수렴 확인

## Why filter (not handle in code)

이 3건은 모두 **사용자 환경/백엔드 측 transient 신호** 임:
- HttpException 502 storage: cdn.picnic.fan/supabase storage 일시 장애 — 앱이 할 수 있는 건 retry/placeholder 노출 정도이고 이미 RetryHttpClient 가 처리
- FunctionException 503 SUPABASE_EDGE_RUNTIME_ERROR: Supabase 플랫폼 outage 신호 — 코드 fix 불가, retry/UX 처리는 별개
- PostgrestException 네트워크 단절: 사용자 인터넷 끊김 — 노이즈

→ Sentry 노이즈를 줄여 진짜 시그널이 묻히지 않게 하는 것이 비용 대비 가장 효과적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)