### PR TITLE
chore(sentry): ANR 진단 옵션 명시화 (attachThreads + anrEnabled)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -81,6 +81,15 @@ class AppInitializer {
       options.enableTimeToFullDisplayTracing = false;
       options.addInAppInclude('sentry-debug-meta.properties');
 
+      // ANR 진단 강화 (PICNIC-APP-45E 등)
+      // - attachThreads: ANR/crash 시점에 모든 thread stack 을 함께 캡처해
+      //   main thread 가 어디서 블로킹됐는지 식별 가능하게 만든다.
+      // - anrEnabled/anrTimeoutInterval 은 default true/5s 이지만, 의도를
+      //   명시적으로 둬 향후 옵션 변경 가능성을 readable 하게 유지.
+      options.attachThreads = true;
+      options.anrEnabled = true;
+      options.anrTimeoutInterval = const Duration(seconds: 5);
+
       options.beforeSend = (event, hint) {
         final exceptionValue =
             event.exceptions?.firstOrNull?.value ?? '';


### PR DESCRIPTION
## Summary

Sentry **PICNIC-APP-45E** (Android ANR, 336 events / 109 users, lastSeen 어제) 등 ANR 이벤트 분석에 필요한 thread stack 캡처를 활성화. 코드 수정이 아닌 **다음 라운드 진단의 입력 품질** 을 올리는 투자 성격의 변경.

## Problem

현재 45E 의 latest event 를 보면 main thread (id=1) stack 이 122 frames 캡처되지만 거의 전부 `_updater/patches/25/dlc.vmcode` (Shorebird OTA patch) 의 unsymbolicated frames 로 채워져 있어 어떤 Dart 함수가 블로킹했는지 식별 불가. 또한 다른 thread (worker isolate, JNI thread 등) 의 상태가 캡처되지 않아 cause-effect 추정이 어려움.

## Changes

`picnic_lib/lib/core/utils/app_initializer.dart` 의 `initializeSentry`:

```dart
options.attachThreads = true;
options.anrEnabled = true;
options.anrTimeoutInterval = const Duration(seconds: 5);
```

- **attachThreads = true** (default `false`): ANR/crash 시 모든 thread (main + workers + JNI) 의 stack 을 함께 첨부. ANR 분석에 결정적
- **anrEnabled = true / anrTimeoutInterval = 5s**: default 와 동일하지만 명시화하여 향후 옵션 조정 의도가 PR diff 로 추적되게 함

## Cost / Risk

- 페이로드 크기: ANR/error event 당 thread stack 만큼 증가 (보통 < 5KB). Sentry 무료 quota 초과 우려 없음
- CPU/네트워크: ANR 시점 1회만 캡처되므로 정상 동작에 영향 없음
- 호환성: sentry_flutter 9.14.0 (현 prod) 부터 지원되는 옵션. 추가 의존성 없음

## Test plan

- [x] `flutter test test/core/utils/app_initializer_test.dart test/core/utils/app_initializer_helper_test.dart` — 115/115 passed
- [ ] 머지 후 다음 릴리스 빌드 → 24~48h prod ANR 이벤트의 thread 정보가 풍부해지는지 확인 → 그 데이터로 45E 의 main isolate 블로커 함수 식별 라운드 시작

## Why minimal scope

이 PR 은 의도적으로 진단 강화만 담음. 실제 ANR 원인(Shorebird patch #25 의 main isolate blocking) fix 는 **데이터를 본 뒤** 별도 PR 로 진행. 가설 기반 수정보다 데이터 기반 수정이 비용 대비 효과가 크기 때문.

🤖 Generated with [Claude Code](https://claude.com/claude-code)