### PR TITLE
chore(ci): Shorebird patch 빌드 후 Sentry 디버그 심볼 업로드

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -804,6 +804,7 @@ workflows:
       groups:
         - shorebird-config
         - picnic_env
+        - sentry-config
       flutter: 3.41.4
       xcode: 26.3
       cocoapods: default
@@ -885,6 +886,50 @@ workflows:
             exit 1
           fi
 
+      - name: Sentry 패치 디버그 심볼 업로드 (iOS)
+        script: |
+          # Shorebird patch 가 새로 빌드한 Dart AOT 코드는 release 빌드와
+          # 다른 debug-id 를 가진다. release 시 업로드된 심볼만 갖고는
+          # OTA 패치 후 발생한 ANR/crash 가 unsymbolicated `_updater/patches/N/dlc.vmcode`
+          # 로 기록되어 분석 불가 (PICNIC-APP-45E 의 원인).
+          # 따라서 patch 빌드 직후에도 symbol 업로드를 수행한다.
+
+          set -e
+          cd picnic_app
+
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "⚠️ Sentry 환경변수 누락 — symbol 업로드 건너뜀"
+            exit 0
+          fi
+
+          # sentry-cli 설치
+          curl -sL https://sentry.io/get-cli/ | bash
+          export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+          sentry-cli --version || { echo "⚠️ sentry-cli 설치 실패"; exit 0; }
+
+          # iOS dSYM (xcarchive 가 있으면)
+          XCARCHIVE=$(find build/ios/archive -name "*.xcarchive" -type d 2>/dev/null | head -1)
+          if [ -n "$XCARCHIVE" ] && [ -d "$XCARCHIVE/dSYMs" ]; then
+            echo "📤 iOS dSYM 업로드: $XCARCHIVE/dSYMs"
+            sentry-cli debug-files upload \
+              --org "$SENTRY_ORG" \
+              --project "$SENTRY_PROJECT" \
+              --include-sources \
+              "$XCARCHIVE/dSYMs" 2>&1 || echo "⚠️ dSYM 업로드 실패 (무시)"
+          else
+            echo "ℹ️ xcarchive 미발견 — Shorebird patch 는 일반적으로 archive 를 만들지 않음"
+          fi
+
+          # Flutter Dart AOT debug info (build/ios 전체 스캔)
+          echo "📤 Flutter Dart 심볼 업로드..."
+          sentry-cli debug-files upload \
+            --org "$SENTRY_ORG" \
+            --project "$SENTRY_PROJECT" \
+            --include-sources \
+            build/ios/ 2>&1 || echo "⚠️ Flutter 심볼 업로드 실패 (무시)"
+
+          echo "✅ Sentry iOS patch 심볼 업로드 단계 완료"
+
     artifacts:
       - picnic_app/flutter_drive.log
 
@@ -913,6 +958,7 @@ workflows:
       groups:
         - shorebird-config
         - picnic_env
+        - sentry-config
       flutter: 3.41.4
       java: 17
       vars:
@@ -997,6 +1043,50 @@ workflows:
             echo "  - 네이티브 코드 변경 여부 확인 (Dart 변경만 패치 가능)"
             exit 1
           fi
+
+      - name: Sentry 패치 디버그 심볼 업로드 (Android)
+        script: |
+          # Shorebird patch 가 새로 빌드한 Dart AOT 코드는 release 빌드와
+          # 다른 debug-id 를 가진다. release 시 업로드된 심볼만 갖고는
+          # OTA 패치 후 발생한 ANR/crash 가 unsymbolicated
+          # `_updater/patches/N/dlc.vmcode` 로 기록되어 분석 불가
+          # (PICNIC-APP-45E 의 직접 원인).
+          # 따라서 patch 빌드 직후에도 symbol 업로드를 수행한다.
+
+          set -e
+          cd picnic_app
+
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "⚠️ Sentry 환경변수 누락 — symbol 업로드 건너뜀"
+            exit 0
+          fi
+
+          # sentry-cli 설치
+          curl -sL https://sentry.io/get-cli/ | bash
+          export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+          sentry-cli --version || { echo "⚠️ sentry-cli 설치 실패"; exit 0; }
+
+          # 1) Native libs (.so) 디버그 심볼
+          NATIVE_LIBS_DIR=$(find build -path "*merged_native_libs*release*" -type d 2>/dev/null | head -1)
+          if [ -n "$NATIVE_LIBS_DIR" ]; then
+            echo "📤 네이티브 라이브러리 심볼 업로드: $NATIVE_LIBS_DIR"
+            sentry-cli debug-files upload \
+              --org "$SENTRY_ORG" \
+              --project "$SENTRY_PROJECT" \
+              "$NATIVE_LIBS_DIR" 2>&1 || echo "⚠️ 네이티브 심볼 업로드 실패 (무시)"
+          else
+            echo "ℹ️ merged_native_libs 디렉토리 미발견"
+          fi
+
+          # 2) Flutter Dart AOT debug info (DWARF)
+          echo "📤 Flutter Dart 심볼 업로드..."
+          sentry-cli debug-files upload \
+            --org "$SENTRY_ORG" \
+            --project "$SENTRY_PROJECT" \
+            --include-sources \
+            build/app/ 2>&1 || echo "⚠️ Flutter 심볼 업로드 실패 (무시)"
+
+          echo "✅ Sentry Android patch 심볼 업로드 단계 완료"
 
     artifacts:
       - picnic_app/flutter_drive.log


### PR DESCRIPTION
## Summary

Sentry **PICNIC-APP-45E** (Android ANR, 336 events / 109 users) 등 OTA 패치 후 발생한 ANR/crash 의 stack trace 가 모두 `_updater/patches/N/dlc.vmcode` 로 **unsymbolicated** 상태. 직접 원인은 Codemagic patch workflow 에서 Sentry 로 디버그 심볼을 올리지 않기 때문.

## Why this matters

| 빌드 종류 | Sentry 심볼 업로드 | 결과 |
|---|---|---|
| `picnic-app-distribute-ios/android` (release) | ✅ 구현됨 (dSYM/native libs/Flutter Dart) | release 빌드 코드의 crash 는 symbolicated |
| **`picnic-app-patch-ios/android` (Shorebird OTA)** | ❌ **누락** | OTA 패치된 Dart 코드의 crash 는 `_updater/patches/N/dlc.vmcode` 로 익명 처리 |

OTA 패치는 새 Dart AOT 빌드 (= 새 debug-id) 를 만든다. release 시 업로드된 심볼만으로는 패치 코드의 crash 를 symbolicate 할 수 없다. 따라서 patch 후에도 동일한 심볼 업로드가 필요.

## Changes

`codemagic.yaml`:

### `picnic-app-patch-ios`
- `environment.groups` 에 `sentry-config` 추가 (SENTRY_AUTH_TOKEN/ORG/PROJECT 주입)
- `shorebird patch ios` 성공 후 새 step:
  - sentry-cli 설치
  - `build/ios/archive/*.xcarchive/dSYMs` 가 있으면 dSYM 업로드
  - `build/ios/` 전체에서 Flutter Dart 심볼 업로드

### `picnic-app-patch-android`
- `environment.groups` 에 `sentry-config` 추가
- `shorebird patch android` 성공 후 새 step:
  - sentry-cli 설치
  - `build/**/merged_native_libs/release` 의 native libs (.so) 업로드
  - `build/app/` 의 Flutter Dart 심볼 업로드

## Safety

- 각 sentry-cli 호출은 `|| echo "..."` 로 fail-safe — 심볼 업로드가 실패해도 patch 배포 자체는 정상 종료
- `SENTRY_AUTH_TOKEN/ORG/PROJECT` 누락 시 graceful skip (`exit 0`)
- 업로드 디렉토리는 release workflow 가 이미 검증한 동일 경로 패턴 사용

## Test plan

- [x] YAML 구조 검증 (`yaml.safe_load` + groups/scripts 키 확인)
- [x] release workflow 의 동일 sentry-cli 명령 패턴 미러링 (이미 prod 에서 동작 중)
- [ ] 머지 후 다음 `picnic-patch-*` 태그 배포 → Codemagic 로그에서 sentry-cli upload 성공 확인
- [ ] 그 패치 적용 후 발생하는 ANR/crash event 의 stack 이 함수명까지 표시되는지 Sentry 에서 확인

## Effect timeline

- 머지 즉시 효과 0 — 다음 OTA 패치 배포 시점부터 적용
- 누적적: 패치 #26, #27, ... 발생하는 ANR/crash 부터 symbolicated
- 기존 patch #25 시점에 이미 발생한 45E 이벤트는 영향 없음 (소급 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)