### PR TITLE
chore(ci): Codemagic patch workflow tag-trigger 제거 + 로컬 패치 스크립트 추가

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -813,13 +813,9 @@ workflows:
     cache:
       cache_paths:
         - $FLUTTER_ROOT/.pub-cache
-    triggering:
-      events:
-        - tag
-      tag_patterns:
-        - pattern: 'picnic-patch-*'
-          include: true
-      cancel_previous_builds: true
+    # NOTE: tag-based triggering 제거됨 (2026-04-26).
+    # 패치는 로컬에서 `picnic_app/scripts/shorebird-patch.sh` 로 진행.
+    # Codemagic 워크플로우는 보존하되 수동 트리거(=콘솔에서 직접 빌드 시작) 전용.
     scripts:
       - name: Setup and Patch iOS
         script: |
@@ -967,13 +963,9 @@ workflows:
       cache_paths:
         - $FLUTTER_ROOT/.pub-cache
         - $HOME/.gradle/caches
-    triggering:
-      events:
-        - tag
-      tag_patterns:
-        - pattern: 'picnic-patch-*'
-          include: true
-      cancel_previous_builds: true
+    # NOTE: tag-based triggering 제거됨 (2026-04-26).
+    # 패치는 로컬에서 `picnic_app/scripts/shorebird-patch.sh` 로 진행.
+    # Codemagic 워크플로우는 보존하되 수동 트리거(=콘솔에서 직접 빌드 시작) 전용.
     scripts:
       - name: Setup and Patch Android
         script: |

--- a/picnic_app/scripts/shorebird-patch.sh
+++ b/picnic_app/scripts/shorebird-patch.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# Local Shorebird OTA patch helper.
+#
+# 사용법:
+#   ./scripts/shorebird-patch.sh <platform> [release-version]
+#
+#   <platform>          : ios | android | both
+#   [release-version]   : 선택. 예: "1.2.27+122701".
+#                         생략 시 pubspec.yaml 의 version 그대로 사용.
+#                         Shorebird 에 등록된 release 와 정확히 일치해야 함.
+#
+# 환경 변수 (Sentry 디버그 심볼 업로드용 - 선택):
+#   SENTRY_AUTH_TOKEN   - debug-files upload 권한 (project:releases) 필요
+#   SENTRY_ORG          - default: icon-casting
+#   SENTRY_PROJECT      - default: picnic-app
+#
+# 예시:
+#   # 현재 prod release(=pubspec.yaml) 에 iOS+Android 패치 + Sentry 심볼 업로드
+#   SENTRY_AUTH_TOKEN=sntry_... ./scripts/shorebird-patch.sh both
+#
+#   # 특정 release 에 Android 만 패치 (심볼 업로드 생략)
+#   ./scripts/shorebird-patch.sh android 1.2.27+122701
+#
+# Codemagic 의 picnic-app-patch-* workflow 는 tag trigger 가 제거된 상태.
+# 패치는 항상 이 스크립트(=로컬)로 진행.
+
+set -euo pipefail
+
+# ---- args ----
+PLATFORM="${1:-}"
+RELEASE_VERSION_OVERRIDE="${2:-}"
+
+if [ -z "$PLATFORM" ]; then
+  echo "Usage: $0 <ios|android|both> [release-version]"
+  exit 1
+fi
+
+case "$PLATFORM" in
+  ios|android|both) ;;
+  *) echo "❌ Invalid platform: $PLATFORM (ios|android|both 중 하나)"; exit 1 ;;
+esac
+
+# ---- locate picnic_app dir ----
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$APP_DIR"
+
+if [ ! -f pubspec.yaml ]; then
+  echo "❌ pubspec.yaml 미발견: $APP_DIR"
+  exit 1
+fi
+
+# ---- determine release version ----
+if [ -n "$RELEASE_VERSION_OVERRIDE" ]; then
+  RELEASE_VERSION="$RELEASE_VERSION_OVERRIDE"
+else
+  RELEASE_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version:[[:space:]]*//' | xargs)
+fi
+
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "❌ release version 결정 실패"
+  exit 1
+fi
+
+# ---- locate shorebird CLI ----
+SHOREBIRD="${SHOREBIRD:-$HOME/.shorebird/bin/shorebird}"
+if [ ! -x "$SHOREBIRD" ]; then
+  if command -v shorebird &>/dev/null; then
+    SHOREBIRD=$(command -v shorebird)
+  else
+    echo "❌ shorebird CLI 미발견. https://docs.shorebird.dev 참고하여 설치"
+    exit 1
+  fi
+fi
+
+# ---- Sentry symbol upload helpers ----
+sentry_upload_check() {
+  if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+    echo "ℹ️ SENTRY_AUTH_TOKEN 미설정 — symbol 업로드 건너뜀"
+    return 1
+  fi
+  if ! command -v sentry-cli &>/dev/null; then
+    echo "ℹ️ sentry-cli 미설치 (brew install getsentry/tools/sentry-cli) — symbol 업로드 건너뜀"
+    return 1
+  fi
+  return 0
+}
+
+sentry_upload_ios() {
+  sentry_upload_check || return 0
+  local org="${SENTRY_ORG:-icon-casting}"
+  local project="${SENTRY_PROJECT:-picnic-app}"
+  echo "📤 Sentry iOS 심볼 업로드..."
+  local xcarchive
+  xcarchive=$(find build/ios/archive -name "*.xcarchive" -type d 2>/dev/null | head -1 || true)
+  if [ -n "$xcarchive" ] && [ -d "$xcarchive/dSYMs" ]; then
+    sentry-cli debug-files upload --org "$org" --project "$project" \
+      --include-sources "$xcarchive/dSYMs" 2>&1 || echo "⚠️ dSYM 업로드 실패 (무시)"
+  fi
+  if [ -d build/ios ]; then
+    sentry-cli debug-files upload --org "$org" --project "$project" \
+      --include-sources build/ios/ 2>&1 || echo "⚠️ Flutter Dart 심볼 업로드 실패 (무시)"
+  fi
+  echo "✅ Sentry iOS 심볼 업로드 단계 완료"
+}
+
+sentry_upload_android() {
+  sentry_upload_check || return 0
+  local org="${SENTRY_ORG:-icon-casting}"
+  local project="${SENTRY_PROJECT:-picnic-app}"
+  echo "📤 Sentry Android 심볼 업로드..."
+  local native_libs
+  native_libs=$(find build -path "*merged_native_libs*release*" -type d 2>/dev/null | head -1 || true)
+  if [ -n "$native_libs" ]; then
+    sentry-cli debug-files upload --org "$org" --project "$project" \
+      "$native_libs" 2>&1 || echo "⚠️ native libs 업로드 실패 (무시)"
+  fi
+  if [ -d build/app ]; then
+    sentry-cli debug-files upload --org "$org" --project "$project" \
+      --include-sources build/app/ 2>&1 || echo "⚠️ Flutter Dart 심볼 업로드 실패 (무시)"
+  fi
+  echo "✅ Sentry Android 심볼 업로드 단계 완료"
+}
+
+# ---- platform-specific patch steps ----
+patch_ios() {
+  echo
+  echo "════════════════════════════════════════"
+  echo "🚀 shorebird patch ios"
+  echo "════════════════════════════════════════"
+  echo "📦 Flutter pub get..."
+  flutter pub get
+  echo "📦 CocoaPods install..."
+  (cd ios && pod install)
+
+  "$SHOREBIRD" patch ios \
+    --release-version="$RELEASE_VERSION" \
+    --no-confirm \
+    --allow-native-diffs \
+    --allow-asset-diffs \
+    --dart-define=ENVIRONMENT=prod \
+    -- --no-codesign
+
+  echo "✅ iOS patch deploy 완료"
+  sentry_upload_ios
+}
+
+patch_android() {
+  echo
+  echo "════════════════════════════════════════"
+  echo "🚀 shorebird patch android"
+  echo "════════════════════════════════════════"
+  echo "📦 Flutter pub get..."
+  flutter pub get
+
+  "$SHOREBIRD" patch android \
+    --release-version="$RELEASE_VERSION" \
+    --no-confirm \
+    --allow-native-diffs \
+    --allow-asset-diffs \
+    --dart-define=ENVIRONMENT=prod
+
+  echo "✅ Android patch deploy 완료"
+  sentry_upload_android
+}
+
+# ---- main ----
+echo "🎯 Target release version: $RELEASE_VERSION"
+echo "📱 Platform: $PLATFORM"
+echo "📁 App dir: $APP_DIR"
+
+case "$PLATFORM" in
+  ios) patch_ios ;;
+  android) patch_android ;;
+  both) patch_ios; patch_android ;;
+esac
+
+echo
+echo "🎉 모든 패치 단계 완료"


### PR DESCRIPTION
## Summary

PR #8 에서 추가한 Codemagic patch workflow 에 Sentry 심볼 업로드 로직은 *실제 패치 경로* 가 아니었음. 패치는 로컬 `shorebird` CLI 로 진행하는 것이 픽닉의 검증된 워크플로우. tag-trigger 가 활성화되어 `picnic-patch-*` 태그 push 시 Codemagic 빌드가 트리거되어 실패하는 사고가 실제로 발생.

## Changes

### `codemagic.yaml`
- `picnic-app-patch-ios` / `picnic-app-patch-android` 의 `triggering:` 섹션 삭제
- 결과: tag push 로 자동 트리거되지 않음 (Codemagic 콘솔에서 수동 빌드는 가능)
- 워크플로우 정의 자체는 보존 — 향후 검증 후 Codemagic 경로 사용 결정 시 재활용

### `picnic_app/scripts/shorebird-patch.sh` (신규)
로컬 패치 + Sentry 심볼 업로드를 한 번에 수행:
```bash
# prod release(=pubspec.yaml) 에 iOS+Android 패치
SENTRY_AUTH_TOKEN=sntry_xxx ./scripts/shorebird-patch.sh both

# 특정 release 만, Android 패치만
./scripts/shorebird-patch.sh android 1.2.27+122701
```
- `SENTRY_AUTH_TOKEN` 미설정 시 심볼 업로드만 graceful skip (패치는 정상 진행)
- release version 인자 미지정 시 `pubspec.yaml` 의 `version` 그대로 사용 (Shorebird 등록 release 와 build 번호까지 일치 필요)

## Why

| 시나리오 | 변경 전 | 변경 후 |
|---|---|---|
| `picnic-patch-*` 태그 실수로 push | Codemagic 빌드 자동 트리거 → 실패 (release version 매칭 불가) | 아무 일 없음 |
| 정상 패치 흐름 | 로컬 CLI + 사용자가 별도로 sentry-cli 호출 | `./scripts/shorebird-patch.sh both` 한 줄 |
| Codemagic 경로 미래 활용 | 트리거 잘못된 상태로 보존 | 정의 보존 + 트리거 제거 → 검증 후 재활성화 가능 |

## Test plan

- [x] codemagic.yaml YAML 구조 검증 (triggering 섹션 부재 확인)
- [x] 스크립트 syntax 검증 (`bash -n`)
- [x] 인자 누락 시 usage 메시지 출력 확인
- [ ] 다음 패치 시 사용자가 `./scripts/shorebird-patch.sh both` 로 실행 → 정상 동작 확인

## Context

- 오늘(2026-04-26) Patch 26 (iOS) / Patch 27 (Android) 가 1.2.27+122701 stable 로 로컬 deploy 됨 (수동 명령)
- 이번 PR 은 그 흐름을 *문서화/스크립트화* 하는 후속 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)