### PR TITLE
chore(sentry): Shorebird 패치 번호를 Sentry tag 로 노출

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -15,6 +15,7 @@ import 'package:picnic_lib/core/utils/app_initializer_helper.dart';
 import 'package:picnic_lib/core/utils/deep_link_handler.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/core/utils/privacy_consent_manager.dart';
+import 'package:picnic_lib/core/utils/shorebird_utils.dart';
 import 'package:picnic_lib/core/utils/system_ui_initializer.dart';
 import 'package:picnic_lib/core/services/push_token_service.dart';
 import 'package:picnic_lib/core/services/app_badge_service.dart';
@@ -107,6 +108,39 @@ class AppInitializer {
       };
     });
     logger.i('Sentry initialized');
+
+    // Shorebird 패치 번호를 Sentry tag 로 등록.
+    // release tag(예: 1.2.27+122701) 만으로는 사용자가 OTA 패치를 적용
+    // 받았는지(=어느 patch 번호인지) 구분 불가. 별도 tag 로 노출해 Sentry
+    // 대시보드에서 patch 번호로 group-by/filter 가능하게 만든다.
+    // SDK init 을 블로킹하지 않도록 fire-and-forget 으로 실행.
+    unawaited(_tagSentryWithShorebirdPatch());
+  }
+
+  /// Reads the active Shorebird patch number and sets it as a Sentry tag.
+  ///
+  /// On web, Shorebird is not supported — skips silently.
+  /// Failures (e.g. shorebird CLI not installed in test env) are logged
+  /// but never thrown.
+  static Future<void> _tagSentryWithShorebirdPatch() async {
+    try {
+      if (kIsWeb) return;
+      final patch = await ShorebirdUtils.checkPatch();
+      final patchNumber = patch?.number;
+      Sentry.configureScope((scope) {
+        scope.setTag(
+          'shorebird.patch_number',
+          patchNumber?.toString() ?? 'none',
+        );
+        scope.setTag(
+          'shorebird.has_patch',
+          patchNumber != null ? 'yes' : 'no',
+        );
+      });
+      logger.i('🏷️ Sentry shorebird tag set: patch_number=$patchNumber');
+    } catch (e, st) {
+      logger.w('Sentry shorebird tag 설정 실패: $e', stackTrace: st);
+    }
   }
 
   static Future<void> initializeGlobalErrorHandling() async {


### PR DESCRIPTION
## Summary

오늘 OTA 패치 26/27 deploy 후 모니터링 중, 47/4ZY/4ZX 등 신규 이벤트가 계속 들어왔습니다. **release tag (예: \`1.2.27+122701\`) 만으로는 사용자가 OTA 패치를 적용 받았는지(=어느 patch 번호인지) 구분 불가** 라서 OTA 미적용 사용자 잔존 vs 필터 누락 vs 새 버그를 판별할 수 없었음.

## Changes

`picnic_lib/lib/core/utils/app_initializer.dart`:

`SentryFlutter.init` 직후 `ShorebirdUtils.checkPatch()` 로 현재 patch 번호를 읽어 Sentry scope tag 로 등록.

```dart
unawaited(_tagSentryWithShorebirdPatch());

static Future<void> _tagSentryWithShorebirdPatch() async {
  if (kIsWeb) return;
  final patch = await ShorebirdUtils.checkPatch();
  Sentry.configureScope((scope) {
    scope.setTag('shorebird.patch_number', patch?.number?.toString() ?? 'none');
    scope.setTag('shorebird.has_patch', patch != null ? 'yes' : 'no');
  });
}
```

## Effect

다음 OTA 패치가 사용자에게 도달한 시점부터 Sentry 대시보드에서:

| tag value | 의미 |
|---|---|
| `shorebird.patch_number = 27` | OTA 적용된 사용자 — 새 필터/fix 도달 |
| `shorebird.patch_number = 26` | 이전 patch 까지만 적용 |
| `shorebird.patch_number = none` | OTA 패치 미적용 (release 빌드 그대로) |

→ "47 이벤트가 patch_number=27 사용자에게서 발생했나?" 같은 질문이 답이 됨. 답이 yes 면 진짜 필터 누락, no 면 OTA 도달 지연.

## Safety

- **블로킹 없음**: `unawaited` fire-and-forget. Sentry SDK init 을 지연시키지 않음
- **웹 안전**: `kIsWeb` 가드
- **실패 안전**: try/catch 로 logger.w 만 기록, throw 안 함
- 기존 의존성 (shorebird_code_push 2.0.5, sentry_flutter 9.14.0) 그대로

## Test plan

- [x] flutter test (app_initializer + app_initializer_helper): 126/126 passed
- [x] flutter analyze: 기존 \`profilesSampleRate\` experimental 경고 외 추가 이슈 없음
- [ ] 다음 OTA 패치 deploy 후 Sentry event 에 \`shorebird.patch_number\` tag 가 표시되는지 확인 → 추후 dashboard query 로 patch 번호별 그룹 분석

## Related

- 본 모니터링 세션의 +152min 알림에서 47+2 발견 → 필터는 매치하지만 release tag 만으로 OTA 적용 여부 판별 불가했던 케이스에 대한 후속 조치
- 향후 Shorebird release tag 가 patch 번호를 포함하지 않는 한 (Shorebird 정책상 변경 안 함) 이 tag 가 유일한 분리 수단

🤖 Generated with [Claude Code](https://claude.com/claude-code)