### PR TITLE
chore(release): bump picnic_app to 1.2.28+122801

### DIFF
--- a/picnic_app/pubspec.yaml
+++ b/picnic_app/pubspec.yaml
@@ -2,7 +2,7 @@ name: picnic_app
 description: "Picnic App"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.2.27+122702
+version: 1.2.28+122801
 
 environment:
     sdk: '>=3.3.1 <4.0.0'


### PR DESCRIPTION
## Summary

신규 store release 빌드용 버전 bump.

## Changes
- `picnic_app/pubspec.yaml`: `1.2.27+122702` → `1.2.28+122801`

## Included PRs
- #3 fix(http): postgrest response.request null check invariant
- #4 chore(deps): sentry_flutter ^9.19.0 (Android JNI segfault 완화)
- #6 fix(sentry): beforeSend filter gaps (47/49W/4ZY/4ZX/4EN)
- #7 chore(sentry): attachThreads (ANR 진단 강화)
- #10 chore(sentry): shorebird.patch_number tag

## Next step

머지 후 `picnic-v1.2.28+122801` 태그 push → Codemagic `picnic-app-ios` / `picnic-app-android` workflow 자동 trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)