### PR TITLE
chore(ios): Podfile.lock 을 1.2.28 release 의 실제 값으로 동기화

### DIFF
--- a/picnic_app/ios/Podfile.lock
+++ b/picnic_app/ios/Podfile.lock
@@ -290,11 +290,11 @@ PODS:
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
-  - Sentry/HybridSDK (8.56.2)
-  - sentry_flutter (9.14.0):
+  - Sentry/HybridSDK (8.58.1)
+  - sentry_flutter (9.19.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.56.2)
+    - Sentry/HybridSDK (= 8.58.1)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -595,8 +595,8 @@ SPEC CHECKSUMS:
   quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
   restart_app: 0714144901e260eae68f7afc2fc4aacc1a323ad2
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  sentry_flutter: 841fa2fe08dc72eb95e2320b76e3f751f3400cf5
+  Sentry: 958d9619ceccf6abb8c4736003fa336dac1a80a7
+  sentry_flutter: bdfd7a7b8931c4ecefa37fde9e44a15cd0af30b1
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418


### PR DESCRIPTION
## Summary

`Sentry/HybridSDK 8.56.2 → 8.58.1` Podfile.lock 동기화. **사용자 영향 0** — 1.2.28 release 빌드 시 Codemagic 이 이미 8.58.1 으로 빌드해 사용자에게 8.58.1 가 도달 중. git 만 옛날 값이었던 것.

## Why

PR #4 (sentry_flutter 9.14 → 9.19) 머지 후 Codemagic 이 1.2.28+122801 release 빌드할 때 native dep 도 8.58.1 으로 자동 resolve. 하지만 git 의 Podfile.lock 은 그 갱신을 commit back 하지 않아 stale 한 채로 남음.

오늘 1.2.28 base OTA 패치 진행 시 `pod install` 가 stale lock 의 8.56.2 vs Podfile 의 9.19 가 요구하는 8.58.1 충돌로 실패. 로컬에서 8.58.1 으로 재생성 후 패치 진행. 그 갱신본을 git 에 동기화하는 PR.

## Effect

- **사용자**: 영향 0 (이미 8.58.1 사용 중)
- **빌드 번호**: bump 불필요
- **다음 OTA 패치**: 같은 pod install 충돌 재발 방지
- **다음 store release 빌드**: Codemagic 이 동일 lock 으로 reproducible build

## Test plan
- [x] `pod install` 로컬 정상 (47 pods, 83 total)
- [x] Shorebird OTA Patch 1 (iOS) / Patch 2 (Android) 1.2.28+122801 base 로 deploy 완료
- [x] Sentry dSYM 업로드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)