### PR TITLE
fix(withdrawal): ProviderContainer capture 로 ref-disposed StateError 차단 (4XZ)

### DIFF
--- a/picnic_lib/lib/presentation/utils/withdrawn_user_guard.dart
+++ b/picnic_lib/lib/presentation/utils/withdrawn_user_guard.dart
@@ -31,11 +31,19 @@ Future<bool> showWithdrawalBlockedDialog({
 
   if (!context.mounted) return true;
 
+  // ProviderContainer 는 ProviderScope subtree 의 root 에서 살아있으며 특정
+  // widget unmount 의 영향을 받지 않는다. dialog 의 onOk 가 호출될 때 호출자
+  // widget 이 이미 deactivate 되었어도 container.read 는 안전하게 작동.
+  // (Sentry PICNIC-APP-4XZ: "Bad state: Using "ref" when a widget is about to
+  //  or has been unmounted is unsafe" — Consumer 의 ref 를 async callback 에서
+  //  쓰면서 발생한 fatal StateError. logoutUser 가 true 인 정상 경로에서 빈번.)
+  final container = ProviderScope.containerOf(context);
+
   showSimpleDialog(
     content: AppLocalizations.of(context).error_message_withdrawal,
     onOk: () {
       if (logoutUser) {
-        ref.read(userInfoProvider.notifier).logout();
+        container.read(userInfoProvider.notifier).logout();
       }
 
       final navContext = navigatorKey.currentContext;


### PR DESCRIPTION
## Summary

Sentry **PICNIC-APP-4XZ** (fatal, 30 events / 5 users) 의 진짜 코드 결함 fix.

```
StateError: Bad state: Using "ref" when a widget is about to or has been
  unmounted is unsafe.
```

## 발생 경로

```
showWithdrawalBlockedDialog (line 12 ~)
  ↓ await ref.read(userInfoProvider.notifier).getUserProfiles()
  ↓ showSimpleDialog(..., onOk: () { ref.read(...).logout() })
  ↓ 사용자가 dialog 띄운 채로 nav (예: 뒤로가기, 다른 탭)
  ↓ 호출자 Consumer widget unmount → ref backing element disposed
  ↓ 사용자가 OK 탭
  ↓ onOk → ref.read → _assertNotDisposed → StateError throw → fatal
```

stack:
- `withdrawn_user_guard.dart:38  showWithdrawalBlockedDialog.<fn>`
- `flutter_riverpod consumer.dart:511  ConsumerStatefulElement.read`
- `flutter_riverpod consumer.dart:432  _assertNotDisposed`

## Fix

`ref` 대신 `ProviderScope.containerOf(context)` 로 **ProviderContainer 를 dialog 표시 전에 캡처**. 

```dart
// before
showSimpleDialog(..., onOk: () { ref.read(...).logout(); ...
});

// after
final container = ProviderScope.containerOf(context);
showSimpleDialog(..., onOk: () { container.read(...).logout(); ...
});
```

`ProviderContainer` 는 `ProviderScope` 의 root 에 살아있으며 특정 widget unmount 와 무관 → async callback 에서 안전. Riverpod 의 canonical "long-running async + ref" 처리 패턴.

## Test plan

- [x] `flutter analyze` — No issues
- [ ] 머지 + OTA patch 후 4XZ 신규 이벤트 0 으로 수렴 확인 (24~48h)

## Effect

- 1.2.28 prod 사용자: 다음 OTA patch 이후 차단
- 1.2.27 OTA patch 적용된 사용자: 같은 OTA 흐름으로 도달
- 4XZ 는 빈도 낮지만 **fatal** 이라 사용자 영향 큰 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)