### PR TITLE
fix(attendance): 4ZY filter 갭 + 4ZX ALREADY_CHECKED 정상 흐름

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -75,6 +75,32 @@ class AppInitializerHelper {
       return true;
     }
 
+    // FunctionException wrapping a user-side network drop / DNS failure
+    // (PICNIC-APP-4ZY in 1.2.28 patch=4: status 500 with NetworkError /
+    // ClientException / SocketException: Failed host lookup payloads).
+    // The wire-level failure is rendered into the message body, not the
+    // status, so the status-based filter above misses it.
+    if (exceptionType == 'FunctionException' &&
+        (exceptionValue.contains('NetworkError') ||
+            exceptionValue.contains('SocketException') ||
+            exceptionValue.contains('Failed host lookup') ||
+            exceptionValue.contains('Connection closed') ||
+            exceptionValue.contains('Connection reset') ||
+            exceptionValue.contains('Connection terminated') ||
+            exceptionValue.contains('HandshakeException'))) {
+      return true;
+    }
+
+    // Attendance: ALREADY_CHECKED is a normal business-rule response
+    // (user already checked in today). The Edge Function returns 409 to
+    // signal it; supabase_flutter throws FunctionException before the
+    // client can read the body. checkIn() handles it as success — drop
+    // the Sentry noise (PICNIC-APP-4ZX in 1.2.28 patch=4).
+    if (exceptionType == 'FunctionException' &&
+        exceptionValue.contains('ALREADY_CHECKED')) {
+      return true;
+    }
+
     // RLS policy violation noise (PICNIC-APP-47)
     if (exceptionType == 'PostgrestException' &&
         exceptionValue.contains('row-level security policy')) {

--- a/picnic_lib/lib/presentation/providers/attendance_provider.dart
+++ b/picnic_lib/lib/presentation/providers/attendance_provider.dart
@@ -123,6 +123,24 @@ class Attendance extends _$Attendance {
         totalReward: data['totalReward'] as int,
       );
     } on FunctionException catch (e, s) {
+      // 409 + ALREADY_CHECKED is a normal business response (user already
+      // checked in today), but supabase_flutter throws before _invokeAndParse
+      // can inspect the body. Re-route to the success path so the state
+      // flips to checked and Sentry stays quiet (PICNIC-APP-4ZX).
+      if (e.status == 409 && _isAlreadyCheckedException(e)) {
+        final current = state.value;
+        if (current != null) {
+          state = AsyncValue.data(
+            AttendanceState(
+              weeklyStatus: current.weeklyStatus,
+              todayChecked: true,
+              serverTimeKST: current.serverTimeKST,
+              deadlineKST: current.deadlineKST,
+            ),
+          );
+        }
+        return null;
+      }
       logger.e('FunctionException during check-in', error: e, stackTrace: s);
       if (!isRetry && (e.status == 401 || e.status == 403)) {
         if (await _tryRefreshSession('checkIn')) {
@@ -271,6 +289,15 @@ class Attendance extends _$Attendance {
         }
       },
     );
+  }
+
+  bool _isAlreadyCheckedException(FunctionException e) {
+    final details = e.details;
+    if (details is Map) {
+      final error = details['error'];
+      if (error is Map && error['code'] == 'ALREADY_CHECKED') return true;
+    }
+    return e.toString().contains('ALREADY_CHECKED');
   }
 
   bool _isAuthError(Object e) {

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -390,6 +390,66 @@ void main() {
         );
       });
 
+      // -------- 1.2.28 patch=4 prod sample (PICNIC-APP-4ZY/4ZX) --------
+
+      test('filters FunctionException 500 wrapping NetworkError + '
+          'Failed host lookup (PICNIC-APP-4ZY patch=4)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 500, details: '
+                "{error: NetworkError: Network connection error: "
+                "ClientException with SocketException: Failed host lookup: "
+                "'xtijtefcycoeqludlngc.supabase.co' (OS Error: No address "
+                'associated with hostname, errno = 7)})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping Connection closed', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 500, details: '
+                '{error: Connection closed before full header was received})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping HandshakeException', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 500, details: '
+                '{error: HandshakeException: Connection terminated})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException ALREADY_CHECKED — normal business '
+          'response, not noise (PICNIC-APP-4ZX patch=4)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 409, details: '
+                '{success: false, error: {message: Already checked in today, '
+                'code: ALREADY_CHECKED}}, reasonPhrase: Conflict)',
+          ),
+          isTrue,
+        );
+      });
+
       // -------- 1.2.28 prod-leak fixes --------
 
       test('filters FunctionException ACCOUNT_DELETED — handled reactively '

--- a/picnic_lib/test/presentation/providers/attendance_provider_auth_test.dart
+++ b/picnic_lib/test/presentation/providers/attendance_provider_auth_test.dart
@@ -447,6 +447,74 @@ void main() {
     });
   });
 
+  group('Attendance provider - authenticated - checkIn 409 ALREADY_CHECKED '
+      '(PICNIC-APP-4ZX patch=4)', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      await setupMockSupabaseWithAuth({
+        'functions:attendance-check:GET': {
+          'success': true,
+          'data': {
+            'weeklyStatus': weeklyStatusJson,
+            'todayChecked': false,
+            'serverTimeKST': '2026-03-11T15:00:00+09:00',
+            'deadlineKST': '2026-03-12T00:00:00+09:00',
+          },
+        },
+        'functions:attendance-check:POST': {
+          'success': false,
+          'error': {
+            'code': 'ALREADY_CHECKED',
+            'message': 'Already checked in today',
+          },
+        },
+      }, userId: 'test-user-id', functionStatusCodes: {
+        'functions:attendance-check:POST': 409,
+      });
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+      tearDownMockSupabase();
+    });
+
+    test('checkIn returns null when server responds 409 ALREADY_CHECKED',
+        () async {
+      container.listen(attendanceProvider, (_, __) {});
+      await container.read(attendanceProvider.future);
+
+      final notifier = container.read(attendanceProvider.notifier);
+      final result = await notifier.checkIn();
+      expect(result, isNull);
+    });
+
+    test('checkIn flips state.todayChecked to true on 409 ALREADY_CHECKED',
+        () async {
+      container.listen(attendanceProvider, (_, __) {});
+      await container.read(attendanceProvider.future);
+
+      final notifier = container.read(attendanceProvider.notifier);
+      await notifier.checkIn();
+
+      final state = container.read(attendanceProvider);
+      expect(state.value!.todayChecked, true);
+    });
+
+    test('checkIn preserves weeklyStatus on 409 ALREADY_CHECKED', () async {
+      container.listen(attendanceProvider, (_, __) {});
+      await container.read(attendanceProvider.future);
+
+      final notifier = container.read(attendanceProvider.notifier);
+      await notifier.checkIn();
+
+      final state = container.read(attendanceProvider);
+      expect(state.value!.weeklyStatus, isNotNull);
+      expect(state.value!.weeklyStatus!.checkedCount, 2);
+    });
+  });
+
   group('Attendance provider - authenticated - checkIn error', () {
     late ProviderContainer container;
 


### PR DESCRIPTION
## Summary
- **4ZY (filter gap)**: 1.2.28 patch=4 에서 `FunctionException(status: 500)` 안에 wrap 된 `NetworkError` / `Failed host lookup` 등 클라이언트 네트워크 단절이 status 기반 502/503/504 필터를 우회해 Sentry 로 새어나옴. `FunctionException` + 네트워크 키워드 조합을 추가 가드.
- **4ZX (정상 흐름)**: `FunctionException(status: 409, code: ALREADY_CHECKED)` 는 "오늘 이미 출석함" 정상 응답인데 `supabase_flutter` 가 body 파싱 전에 throw 하여 `_invokeAndParse` 의 `onAlreadyChecked` 가 호출되지 못하고 Sentry 보고됨. `attendance_provider.checkIn` 의 `FunctionException` catch 에서 409 + ALREADY_CHECKED 를 감지해 todayChecked=true 로 상태 전이 후 null 반환.
- Sentry beforeSend filter 에도 동일 패턴을 노이즈로 추가해 잔여 보고를 차단 (`ALREADY_CHECKED` 자체도 노이즈로 분류).

## Test plan
- [x] `flutter test test/core/utils/app_initializer_helper_test.dart test/presentation/providers/attendance_provider_auth_test.dart` 통과 (121 tests)
- [x] 신규: filter 4건 (NetworkError 500, Connection closed, HandshakeException, ALREADY_CHECKED 409)
- [x] 신규: provider 409 mock 3건 (returns null / state.todayChecked=true / weeklyStatus 보존)
- [ ] OTA 배포 후 Sentry 4ZY/4ZX 이벤트 발생률 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)