### PR TITLE
fix(vote): pull-to-refresh 중 페이지 dispose 시 StateError 차단

### DIFF
--- a/picnic_lib/lib/presentation/pages/vote/vote_home_page.dart
+++ b/picnic_lib/lib/presentation/pages/vote/vote_home_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
+import 'package:picnic_lib/data/models/reward.dart';
 import 'package:picnic_lib/data/models/vote/vote.dart';
 import 'package:picnic_lib/l10n.dart';
 import 'package:picnic_lib/l10n/app_localizations.dart';
@@ -149,7 +150,14 @@ class _VoteHomePageState extends ConsumerState<VoteHomePage>
           _rewardListKey = UniqueKey();
         });
 
-        final rewardFuture = ref.read(asyncRewardListProvider.future);
+        // 페이지가 dispose 되면 provider 도 dispose 되어 future 가 StateError 로
+        // reject 되므로 swallow. (Sentry PICNIC-APP-57B)
+        final rewardFuture = ref
+            .read(asyncRewardListProvider.future)
+            .catchError((Object e, StackTrace s) {
+              logger.w('asyncRewardListProvider refresh interrupted: $e');
+              return const <RewardModel>[];
+            });
 
         final voteCompleter = Completer<void>();
         void listener() {
@@ -164,7 +172,11 @@ class _VoteHomePageState extends ConsumerState<VoteHomePage>
         _pagingController.addListener(listener);
         _pagingController.refresh();
 
-        await Future.wait([rewardFuture, voteCompleter.future]);
+        try {
+          await Future.wait([rewardFuture, voteCompleter.future]);
+        } catch (e, s) {
+          logger.w('vote_home onRefresh interrupted: $e', stackTrace: s);
+        }
       },
       child: ListView(
         children: [


### PR DESCRIPTION
## Summary
- Sentry **[PICNIC-APP-57B](https://icon-casting.sentry.io/issues/PICNIC-APP-57B)** (`StateError: provider asyncRewardListProvider was disposed during loading state`) 의 진짜 원인 차단
- `vote_home_page` 의 `RefreshIndicator.onRefresh` 안에서 `ref.read(asyncRewardListProvider.future)` 로 받은 future 가 페이지 dispose 시 reject → unhandled async error
- `rewardFuture.catchError` 로 폴백 + `Future.wait` 자체도 try/catch 로 감쌈

## Why this approach
이전 PR #15 의 `ProviderContainer.containerOf(context)` capture 패턴은 **ref.read 시점이 disposed** 인 경우용입니다.
이번은 **future 가 in-flight 상태에서 provider dispose 로 reject** 되는 케이스라, future 쪽 catchError 가 더 적합합니다.

## Test plan
- [ ] vote home 에서 pull-to-refresh 즉시 다른 탭으로 이동 → 크래시/Sentry 이벤트 발생 안 함 확인
- [ ] 정상 pull-to-refresh 완료 → reward list/vote list 정상 갱신 확인
- [ ] Sentry PICNIC-APP-57B 가 다음 릴리스 이후 재발하지 않는지 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)