### PR TITLE
fix(sentry): 네이티브 URLSession 자동 5xx 캡쳐 차단 (광고 SDK 노이즈)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -92,6 +92,14 @@ class AppInitializer {
       options.anrEnabled = true;
       options.anrTimeoutInterval = const Duration(seconds: 5);
 
+      // 네이티브 SDK 의 URLSession/OkHttp 자동 5xx 캡쳐(SentryNetworkTracker)
+      // 를 끈다. 이 경로는 Flutter beforeSend 를 우회하므로 광고 SDK
+      // (Pangle/AdMob/Branch 등) 의 텔레메트리 5xx 가 그대로 누적된다
+      // (PICNIC-APP-9E: 8216 events / 323 users). 우리 백엔드 5xx 는
+      // PostgrestException / FunctionException 같은 SDK 별 exception 으로
+      // 이미 캡쳐되므로 시야 손실 없음.
+      options.captureFailedRequests = false;
+
       options.beforeSend = (event, hint) {
         final exceptionValue =
             event.exceptions?.firstOrNull?.value ?? '';

--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -98,7 +98,10 @@ class AppInitializer {
       // (PICNIC-APP-9E: 8216 events / 323 users). 우리 백엔드 5xx 는
       // PostgrestException / FunctionException 같은 SDK 별 exception 으로
       // 이미 캡쳐되므로 시야 손실 없음.
-      options.captureFailedRequests = false;
+      //
+      // sentry_flutter 9.14+ 의 captureNativeFailedRequests 만 false 로 두어
+      // Dart-side (SentryHttpClient/dio) 캡쳐 동작은 그대로 유지한다.
+      options.captureNativeFailedRequests = false;
 
       options.beforeSend = (event, hint) {
         final exceptionValue =


### PR DESCRIPTION
## Summary
- Sentry **[PICNIC-APP-9E](https://icon-casting.sentry.io/issues/PICNIC-APP-9E)** (`HTTPClientError 500`, **8216 events / 323 users 누적**) 원인 차단
- iOS 네이티브 \`SentryNetworkTrackingIntegration\` 이 모든 \`URLSession\` 5xx 응답을 자동 캡쳐 → Flutter \`beforeSend\` 우회 → 기존 \`networkNoiseTypes\` 필터로 차단 불가
- 캡쳐된 URL 들은 100% 광고/분석 SDK 텔레메트리 (Pangle, Branch, AdMob)

## Fix
\`options.captureFailedRequests = false\` 추가하여 네이티브 자동 5xx 캡쳐 완전 차단.

## Why this is safe
우리 백엔드의 5xx 는 SDK 별 typed exception 으로 이미 잡힘:
- Supabase REST → \`PostgrestException\`
- Supabase Edge Functions → \`FunctionException\`
- 그 외 직접 \`Sentry.captureException\` 호출 경로

따라서 시야 손실 없음. \`AppInitializerHelper.shouldFilterSentryEvent\` 의 \`HTTPClientError\` 필터(line 27)는 Flutter-level 캡쳐 대응용으로 그대로 유지.

## Test plan
- [ ] OTA 패치 적용 후 24-48h: PICNIC-APP-9E 신규 이벤트 0 으로 수렴 확인
- [ ] 우리 백엔드 5xx (PostgrestException / FunctionException) 는 정상 캡쳐되는지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)