### PR TITLE
fix(sentry): FunctionException/PostgrestException 의 timeout + 추가 네트워크 패턴 필터

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -38,6 +38,25 @@ class AppInitializerHelper {
       return true;
     }
 
+    // Wrapped network/transport noise patterns — used by both
+    // FunctionException and PostgrestException blocks below. The actual
+    // wire-level error (timeout, DNS, TCP reset) is rendered into the
+    // wrapping exception's message body, so the exact-type filter above
+    // misses them.
+    bool isWrappedNetworkNoise(String v) =>
+        v.contains('NetworkError') ||
+        v.contains('SocketException') ||
+        v.contains('HandshakeException') ||
+        v.contains('Failed host lookup') ||
+        v.contains('Connection closed') ||
+        v.contains('Connection reset') ||
+        v.contains('Connection terminated') ||
+        v.contains('TimeoutException') || // PICNIC-APP-4ZX: 30s request timeout
+        v.contains('Software caused connection abort') || // Android net swap
+        v.contains('Connection abort') ||
+        v.contains('Connection failed') ||
+        v.contains('Network is unreachable');
+
     // Soft-deleted account signal — handled reactively by
     // AccountDeletionHandler (sign-out side effect fires from beforeSend).
     // Drop the Sentry event so it does not flood as noise on every Edge
@@ -75,6 +94,17 @@ class AppInitializerHelper {
       return true;
     }
 
+    // Edge Function wrapping a user-side network drop / timeout
+    // (PICNIC-APP-4ZX, 4ZY). supabase_flutter throws FunctionException with
+    // status=500 and the underlying transport error (TimeoutException /
+    // SocketException / Connection reset / Network is unreachable / etc.)
+    // rendered into the details body. The status-based filter above only
+    // catches gateway-side 5xx; this block catches client-side network noise.
+    if (exceptionType == 'FunctionException' &&
+        isWrappedNetworkNoise(exceptionValue)) {
+      return true;
+    }
+
     // RLS policy violation noise (PICNIC-APP-47)
     if (exceptionType == 'PostgrestException' &&
         exceptionValue.contains('row-level security policy')) {
@@ -94,17 +124,11 @@ class AppInitializerHelper {
       return true;
     }
 
-    // Postgrest wrapping a user-side network drop (PICNIC-APP-47).
+    // Postgrest wrapping a user-side network drop / timeout (PICNIC-APP-47).
     // The wire-level error is rendered into the message, not the type, so
     // exact-type filters above miss it. Drop these as user-environment noise.
     if (exceptionType == 'PostgrestException' &&
-        (exceptionValue.contains('NetworkError') ||
-            exceptionValue.contains('SocketException') ||
-            exceptionValue.contains('HandshakeException') ||
-            exceptionValue.contains('Failed host lookup') ||
-            exceptionValue.contains('Connection closed') ||
-            exceptionValue.contains('Connection reset') ||
-            exceptionValue.contains('Connection terminated'))) {
+        isWrappedNetworkNoise(exceptionValue)) {
       return true;
     }
 

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -390,6 +390,91 @@ void main() {
         );
       });
 
+      // -------- PICNIC-APP-4ZX: wrapped network/timeout in FunctionException
+      test('filters FunctionException wrapping TimeoutException '
+          '(PICNIC-APP-4ZX)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue:
+                'FunctionException(status: 500, details: {error: '
+                'TimeoutException after 0:00:30.000000: Request timed out '
+                'after 30 seconds}, reasonPhrase: Network Error)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping Software caused '
+          'connection abort (Android net swap)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue:
+                'FunctionException(status: 500, details: {error: '
+                'NetworkError: Network connection error: ClientException: '
+                'Software caused connection abort, '
+                'uri=https://xtijtefcycoeqludlngc.supabase.co/functions/v1/'
+                'attendance-check}, reasonPhrase: Network Error)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping Connection reset by peer', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue:
+                'FunctionException(status: 500, details: {error: '
+                'ClientException: Failed to send request: ClientException: '
+                'Connection reset by peer, '
+                'uri=https://xtijtefcycoeqludlngc.supabase.co/functions/v1/'
+                'attendance-check}, reasonPhrase: Network Error)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping Network is unreachable', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue:
+                'FunctionException(status: 500, details: {error: '
+                'NetworkError: Network connection error: ClientException with '
+                'SocketException: Connection failed (OS Error: Network is '
+                'unreachable, errno = 101), '
+                'address = xtijtefcycoeqludlngc.supabase.co}, '
+                'reasonPhrase: Network Error)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters PostgrestException wrapping TimeoutException', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'PostgrestException',
+            exceptionValue:
+                'PostgrestException(message: {"error": "TimeoutException '
+                'after 0:00:30.000000: Request timed out after 30 seconds"}, '
+                'code: 500, details: Network Error, hint: null)',
+          ),
+          isTrue,
+        );
+      });
+
       // -------- 1.2.28 prod-leak fixes --------
 
       test('filters FunctionException ACCOUNT_DELETED — handled reactively '


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-4ZX](https://icon-casting.sentry.io/issues/PICNIC-APP-4ZX)** (\`FunctionException(status:500, …)\` — **1101 events / 209 users 누적**) 의 80%+ 가 \`TimeoutException\` 인데 기존 \`AppInitializerHelper.shouldFilterSentryEvent\` filter 에서 누락된 것을 발견.

### 원인
이벤트 value 형태:
\`\`\`
FunctionException(status:500, details:{error: TimeoutException after 0:00:30.000000:
 Request timed out after 30 seconds}, reasonPhrase: Network Error)
\`\`\`

- 기존 filter 의 \`'NetworkError'\` (공백없음) 은 매칭 안 됨 (이 메시지는 \`Network Error\` 공백 있음)
- \`TimeoutException\` 키워드는 filter 에 아예 없음

### Fix
- \`isWrappedNetworkNoise()\` helper 로 패턴 세트 일원화
- FunctionException / PostgrestException 양쪽에서 동일 helper 호출
- 누락 패턴 추가: \`TimeoutException\`, \`Software caused connection abort\`, \`Connection abort\`, \`Connection failed\`, \`Network is unreachable\`

### Why this is safe
실제 서버 버그 (\`Internal Server Error 500\` 등) 는 패턴에 안 걸리므로 그대로 캡쳐. \`'does not filter FunctionException with 500'\` 테스트로 회귀 방어.

## Test plan
- [x] 4 신규 케이스 추가 + 96 tests pass (\`flutter test app_initializer_helper_test.dart\`)
- [ ] OTA 패치 적용 후 24-48h: PICNIC-APP-4ZX, PICNIC-APP-4ZY, PICNIC-APP-51Y/47 신규 이벤트 0 으로 수렴 확인
- [ ] 실제 백엔드 5xx (TimeoutException 외) 는 정상 캡쳐되는지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)