### PR TITLE
fix(sentry): SIGNUP_UNVERIFIED filter — 이메일 미인증 비즈니스 신호

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -66,6 +66,15 @@ class AppInitializerHelper {
       return true;
     }
 
+    // Email-unverified signup — Edge Function returns 403 + SIGNUP_UNVERIFIED
+    // for users who haven't completed email verification (e.g. ad_shortform
+    // reward gating). It's a business-rule signal handled by the UI, not a
+    // bug (PICNIC-APP-4EN: 322 users / 868 events).
+    if (exceptionType == 'FunctionException' &&
+        exceptionValue.contains('SIGNUP_UNVERIFIED')) {
+      return true;
+    }
+
     // Supabase SDK internal TypeError (PICNIC-APP-T2)
     if (exceptionType == 'TypeError' &&
         exceptionValue.contains('Null check operator used on a null value')) {

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -493,6 +493,22 @@ void main() {
         );
       });
 
+      test('filters FunctionException SIGNUP_UNVERIFIED — email unverified '
+          'business signal (PICNIC-APP-4EN)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue:
+                'FunctionException(status: 403, details: {error: '
+                'signup_unverified, code: SIGNUP_UNVERIFIED}, '
+                'reasonPhrase: Forbidden)',
+          ),
+          isTrue,
+        );
+      });
+
       test('filters HandshakeException as network noise (TLS failures, '
           'PICNIC-APP-47 in 1.2.28)', () {
         expect(


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-4EN](https://icon-casting.sentry.io/issues/PICNIC-APP-4EN)** (**322 users / 868 events 누적**) 는 \`FunctionException(status: 403, details: {error: signup_unverified, code: SIGNUP_UNVERIFIED}, reasonPhrase: Forbidden)\` — 이메일 미인증 사용자가 광고 reward (ad_shortform) 같은 검증 게이트를 호출할 때 발생하는 **정상 비즈니스 신호**.

## Fix
\`ACCOUNT_DELETED\` / \`ALREADY_CHECKED\` 와 같은 패턴으로 \`AppInitializerHelper.shouldFilterSentryEvent\` 에 한 줄 추가.

## Test plan
- [x] 신규 케이스 추가 + 97 tests pass
- [ ] OTA 패치 후 24-48h: PICNIC-APP-4EN 신규 이벤트 0 으로 수렴 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)