### PR TITLE
fix(ref-unmount): voting/계정 삭제 async catch 에서 ref→container

### DIFF
--- a/picnic_lib/lib/presentation/pages/my_page/my_profile.dart
+++ b/picnic_lib/lib/presentation/pages/my_page/my_profile.dart
@@ -307,6 +307,10 @@ class _SettingPageState extends ConsumerState<MyProfilePage> {
   }
 
   Future<void> _deleteAccount() async {
+    // ProviderContainer 캡쳐 — delete-user Edge Function 호출 중 setting page
+    // 가 unmount 되면 (사용자가 뒤로가기 등) ref 접근이 StateError 를 던진다
+    // (PICNIC-APP-W1). container 는 ProviderScope root 와 함께 살아있어 안전.
+    final container = ProviderScope.containerOf(context);
     try {
       // 현재 로그인된 사용자 가져오기
       final user = supabase.auth.currentUser;
@@ -333,9 +337,11 @@ class _SettingPageState extends ConsumerState<MyProfilePage> {
 
       if (response.statusCode == 200) {
         logger.i('User deleted successfully');
-        ref.read(navigationInfoProvider.notifier).setBottomNavigationIndex(0);
-        ref.read(userInfoProvider.notifier).logout();
-        ref.read(navigationInfoProvider.notifier).setResetStackMyPage();
+        container
+            .read(navigationInfoProvider.notifier)
+            .setBottomNavigationIndex(0);
+        container.read(userInfoProvider.notifier).logout();
+        container.read(navigationInfoProvider.notifier).setResetStackMyPage();
 
         if (!mounted) return;
         if (context.mounted) {

--- a/picnic_lib/lib/presentation/widgets/vote/voting/voting_dialog.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/voting/voting_dialog.dart
@@ -468,6 +468,10 @@ class _VotingDialogState extends ConsumerState<VotingDialog> {
   }
 
   Future<void> _performVoting(int voteAmount, String userId) async {
+    // ProviderContainer 캡쳐 — async 작업 도중/이후 dialog 가 unmount 되어도
+    // (사용자가 다른 탭으로 이동/뒤로가기) catch 블록의 provider 접근이 안전
+    // 하도록 함수 시작 시 container 를 보관 (PICNIC-APP-530).
+    final container = ProviderScope.containerOf(context);
     try {
       // 사용량 계산
       final usage = _calculateUsage(voteAmount);
@@ -531,18 +535,22 @@ class _VotingDialogState extends ConsumerState<VotingDialog> {
       logger.e('error', error: e, stackTrace: s);
       _loadingKey.currentState?.hide();
 
-      // 투표 실패 시 롤백: 서버 데이터로 새로고침
-      ref
+      // 투표 실패 시 롤백: 서버 데이터로 새로고침.
+      // dialog 가 unmount 되어 ref 가 disposed 일 수 있으므로 capture 한
+      // container 사용 (PICNIC-APP-530).
+      container
           .read(asyncVoteItemListProvider(voteId: widget.voteModel.id).notifier)
           .fetch(voteId: widget.voteModel.id);
-      ref.read(userInfoProvider.notifier).getUserProfiles();
+      container.read(userInfoProvider.notifier).getUserProfiles();
 
       // 투표 실패 시 버튼 다시 활성화
       if (mounted) {
         setState(() => _isVoting = false);
       }
 
-      Navigator.of(context).pop();
+      if (context.mounted) {
+        Navigator.of(context).pop();
+      }
 
       _showVotingFailDialog();
     }


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-530](https://icon-casting.sentry.io/issues/PICNIC-APP-530)** (26u/34e) + **[PICNIC-APP-W1](https://icon-casting.sentry.io/issues/PICNIC-APP-W1)** (6u/41e) — \`StateError: Using "ref" when a widget is about to or has been unmounted is unsafe\` 두 케이스 fix.

| 위치 | 시나리오 |
|---|---|
| \`voting_dialog._performVoting\` line 535-538 | voting Edge Function 호출 중 다른 탭/페이지로 이동 → dialog unmount → catch 의 \`ref.read\` StateError |
| \`my_profile._deleteAccount\` line 336-338 | delete-user 호출 중 setting page unmount → 200 OK 후 \`ref.read\` 3번 호출에서 StateError |

## Fix
PR #15 의 **ProviderContainer-capture 패턴** 재사용:
\`\`\`dart
final container = ProviderScope.containerOf(context); // 함수 시작 시 capture
// ... async work ...
container.read(...); // unmount 후에도 안전
\`\`\`

추가: voting_dialog 의 \`Navigator.pop\` 도 \`context.mounted\` 가드.

## Test plan
- [ ] 투표 도중 다른 탭 이동 → StateError 없음 / 다음 진입 시 정상 동작
- [ ] 계정 삭제 도중 뒤로가기 → StateError 없음 / 삭제는 정상 완료
- [ ] OTA 패치 후 24-48h: PICNIC-APP-530 / W1 신규 이벤트 0 으로 수렴 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)