### PR TITLE
fix(sentry): String-typed wrapped network noise filter (PICNIC-APP-3R, 4RP)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -92,6 +92,16 @@ class AppInitializerHelper {
       return true;
     }
 
+    // String-typed wrapping of typed exceptions
+    // (PICNIC-APP-3R: PostgrestException + Failed host lookup,
+    //  PICNIC-APP-4RP: AuthRetryableFetchException + HandshakeException).
+    // Some code path stringifies the typed exception before re-throwing or
+    // before passing to FlutterError.onError. The wire-level error is still
+    // embedded in the message, so reuse the same wrapped-network patterns.
+    if (exceptionType == 'String' && isWrappedNetworkNoise(exceptionValue)) {
+      return true;
+    }
+
     // Edge Function transient gateway errors (502/503/504)
     // 503 SUPABASE_EDGE_RUNTIME_ERROR is a Supabase platform-side outage
     // signal, not a picnic bug (PICNIC-APP-4ZY/4ZX/4EN).

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -509,6 +509,56 @@ void main() {
         );
       });
 
+      test('filters String-typed PostgrestException wrapping Failed host '
+          'lookup (PICNIC-APP-3R)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'String',
+            exceptionValue:
+                'PostgrestException(message: {"error": "NetworkError: '
+                'Network connection error: ClientException with '
+                'SocketException: Failed host lookup: '
+                '\'xtijtefcycoeqludlngc.supabase.co\' '
+                '(OS Error: No address associated with hostname, errno = 7)"}, '
+                'code: 500, details: Network Error, hint: null)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters String-typed AuthRetryableFetchException wrapping '
+          'HandshakeException (PICNIC-APP-4RP)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'String',
+            exceptionValue:
+                'AuthRetryableFetchException(message: {"error": '
+                '"ClientException: Failed to send request: HandshakeException: '
+                'Connection terminated during handshake, '
+                'uri=https://xtijtefcycoeqludlngc.supabase.co/auth/v1/token?'
+                'grant_type=refresh_token"}, statusCode: 500)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('does not filter String type with unrelated message', () {
+        // 회귀 보호: 일반 String throw 는 그대로 캡쳐
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'String',
+            exceptionValue: 'some unrelated business error',
+          ),
+          isFalse,
+        );
+      });
+
       test('filters HandshakeException as network noise (TLS failures, '
           'PICNIC-APP-47 in 1.2.28)', () {
         expect(


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-3R](https://icon-casting.sentry.io/issues/PICNIC-APP-3R)** (93u/1500e) + **[PICNIC-APP-4RP](https://icon-casting.sentry.io/issues/PICNIC-APP-4RP)** (10u/20e) 모두 \`exceptionType=String\` 으로 캡쳐된 typed-exception 의 stringified 형태:

| Issue | Wrapping |
|---|---|
| 3R | \`String: PostgrestException(... Failed host lookup ...)\` |
| 4RP | \`String: AuthRetryableFetchException(... HandshakeException ...)\` |

기존 \`PostgrestException\`/\`AuthRetryableFetchException\` 타입 기반 filter 가 매칭 안 됨.

## Fix
PR #20 에서 추출한 \`isWrappedNetworkNoise()\` 패턴 셋을 String 타입에도 적용. 일반 String throw 는 \`TimeoutException\`/\`SocketException\` 같은 키워드가 우연히 들어갈 가능성 극히 낮아 안전 — 회귀 보호 테스트 (\`some unrelated business error\` → 통과) 추가.

## Test plan
- [x] 신규 케이스 2건 + 회귀 보호 1건 + 100 tests pass
- [ ] OTA 패치 후 24-48h: PICNIC-APP-3R / 4RP 신규 이벤트 0 으로 수렴 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)