### PR TITLE
fix(ad-noise): Tapjoy SDK 미연결 / iOS NSURLError 비보고 처리

### DIFF
--- a/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/ad_platform.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/ad_platform.dart
@@ -361,6 +361,14 @@ abstract class AdPlatform {
       '광고가 없습니다',
       '광고 로드 실패',
       '광고 로드 시간 초과',
+      // Tapjoy SDK 미연결 (초기화 race / 백그라운드 복귀 race) — 사용자 환경
+      // 또는 SDK lifecycle 이슈, 우리 코드 버그 아님 (PICNIC-APP-43M)
+      'sdk is not connected',
+      // iOS NSURLError 계열 (-1001 timeout / -1009 not connected / -1003 cannot
+      // find host / -1004 cannot connect to host 등) — 사용자 네트워크 환경
+      // (PICNIC-APP-43N: '작업을 완료할 수 없습니다. Server Error With Status Code:-1001')
+      'server error with status code:-',
+      '작업을 완료할 수 없습니다',
     ];
 
     return nonReportableKeywords

--- a/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/ad_platform_test.dart
+++ b/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/ad_platform_test.dart
@@ -41,6 +41,9 @@ void main() {
         '광고가 없습니다',
         '광고 로드 실패',
         '광고 로드 시간 초과',
+        'sdk is not connected',
+        'server error with status code:-',
+        '작업을 완료할 수 없습니다',
       ];
 
       return nonReportableKeywords
@@ -97,6 +100,38 @@ void main() {
       expect(
         isNonReportableAdError('Pangle', 'error', 'AD not_ready'),
         isTrue,
+      );
+    });
+
+    test('Tapjoy SDK is not connected is non-reportable (PICNIC-APP-43M)', () {
+      expect(
+        isNonReportableAdError(
+            'Tapjoy', 'error', 'Tapjoy SDK is not connected'),
+        isTrue,
+      );
+    });
+
+    test('iOS NSURLError negative status code is non-reportable '
+        '(PICNIC-APP-43N)', () {
+      // -1001 (timeout)
+      expect(
+        isNonReportableAdError('Tapjoy', 'error',
+            '작업을 완료할 수 없습니다. Server Error With Status Code:-1001'),
+        isTrue,
+      );
+      // -1009 (not connected)
+      expect(
+        isNonReportableAdError(
+            'Tapjoy', 'error', 'Server Error With Status Code:-1009'),
+        isTrue,
+      );
+    });
+
+    test('positive HTTP status (500) IS reportable (sanity)', () {
+      expect(
+        isNonReportableAdError(
+            'Tapjoy', 'error', 'Server Error With Status Code:500'),
+        isFalse,
       );
     });
 


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-43M](https://icon-casting.sentry.io/issues/PICNIC-APP-43M)** (Tapjoy SDK is not connected — 23u/169e) + **[PICNIC-APP-43N](https://icon-casting.sentry.io/issues/PICNIC-APP-43N)** (Server Error With Status Code:-1001 — 33u/239e) 모두 \`isNonReportableAdError\` keyword 목록에서 누락된 광고 SDK / 사용자 네트워크 환경 노이즈.

## Fix
\`ad_platform.dart\` 의 \`nonReportableKeywords\` 에 추가:
- \`'sdk is not connected'\` (Tapjoy SDK lifecycle/race)
- \`'server error with status code:-'\` (iOS NSURLError 음수 코드 전반: -1001/-1009/-1003/-1004 …)
- \`'작업을 완료할 수 없습니다'\` (iOS 한국어 NSError localizedDescription)

## Why this is safe
positive HTTP status (500) 는 그대로 reportable — 회귀 보호 테스트 포함.

## Test plan
- [x] 31 tests pass (\`ad_platform_test.dart\` 신규 케이스 3건 + 회귀 1건)
- [ ] OTA 패치 후 24-48h: PICNIC-APP-43M / 43N 신규 이벤트 0 으로 수렴 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)