### PR TITLE
fix(sentry): AuthSessionMissingException filter (PICNIC-APP-508)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -186,6 +186,13 @@ class AppInitializerHelper {
       return true;
     }
 
+    // Auth session missing — refreshSession() 호출 시 세션이 없는 정상 상태.
+    // attendance 등 인증 필요 API 에서 401/403 → 세션 갱신 시도 → 세션 부재로
+    // 401 → 사용자에게 재로그인 안내하는 self-healing 흐름의 일부 (PICNIC-APP-508).
+    if (exceptionType == 'AuthSessionMissingException') {
+      return true;
+    }
+
     return false;
   }
 

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -686,6 +686,20 @@ void main() {
         );
       });
 
+      test('filters AuthSessionMissingException — self-healing re-login '
+          'flow (PICNIC-APP-508)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'AuthSessionMissingException',
+            exceptionValue: 'AuthSessionMissingException(message: '
+                'Auth session missing!, statusCode: 400)',
+          ),
+          isTrue,
+        );
+      });
+
       test('still does NOT filter actionable AuthApiException — e.g. '
           'user_banned should surface (handled separately, not noise)', () {
         expect(


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-508](https://icon-casting.sentry.io/issues/PICNIC-APP-508)** (9u/9e): \`AuthSessionMissingException(message: Auth session missing!, statusCode: 400)\` at \`attendance_provider._tryRefreshSession\`.

\`supabase.auth.refreshSession()\` 호출 시 세션 자체가 없는 self-healing 흐름의 일부 — 401/403 → refreshSession → 세션 없음 → false 반환 → UI 가 재로그인 안내.

## Fix
\`AppInitializerHelper.shouldFilterSentryEvent\` 에 type-only 한 줄 추가.

## Test plan
- [x] 101 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)