### PR TITLE
fix(auth): signOut best-effort — 소셜 logout 실패 시 local state 정리

### DIFF
--- a/picnic_lib/lib/core/services/auth/auth_service.dart
+++ b/picnic_lib/lib/core/services/auth/auth_service.dart
@@ -237,17 +237,28 @@ class AuthService {
   Future<bool> _refreshSession() => refreshSession();
 
   Future<void> signOut() async {
+    // Best-effort logout: 소셜 provider logout 이 unknown 에러로 실패해도
+    // local auth state 는 항상 정리한다. provider logout 자체는 idempotent
+    // 하므로 silent fail 이 사용자 UX 에 더 좋고, unknown 에러는 PicnicAuth
+    // Exceptions.unknown 으로 wrap 되어 Sentry 에 노이즈로 쌓였음
+    // (PICNIC-APP-4XS: GoogleLogin.logout unknown — 7u/9e).
     try {
       final session = await _storageService.getSession();
       if (session != null) {
         final provider = _getProviderFromSession(session);
-        await _logoutFromProvider(provider);
+        try {
+          await _logoutFromProvider(provider);
+        } catch (e, s) {
+          logger.w(
+            'Social provider logout failed (proceeding with local cleanup)',
+            error: e,
+            stackTrace: s,
+          );
+        }
         await DeviceManager.updateLastSeen();
       }
+    } finally {
       await _clearAuthState();
-    } catch (e, s) {
-      logger.e('Error during sign out', error: e, stackTrace: s);
-      rethrow;
     }
   }
 


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-4XS](https://icon-casting.sentry.io/issues/PICNIC-APP-4XS)** (\`PicnicAuthException unknown\` at \`GoogleLogin.logout\` — 7u/9e) 의 진짜 부작용은 사실 더 큼: \`_clearAuthState()\` 가 실행 안 되어 **사용자가 logout 했는데 local state 가 남음**.

## Fix
\`AuthService.signOut()\` 을 \`try/finally\` 패턴으로 변경:
- 내부 try: \`_logoutFromProvider\` 호출, 실패 시 \`logger.w\` 만 남기고 swallow (소셜 logout 은 idempotent)
- \`finally\`: \`_clearAuthState()\` 항상 실행

## Why this is safe
caller 둘 다 exception tolerate:
- \`account_deletion_handler\`: 자체 try/catch + supabase fallback
- \`user_info_provider\`: fire-and-forget (no await)

## Test plan
- [x] 기존 76 tests pass (\`test/core/services/auth/auth_service_test.dart\`)
- [ ] 로그아웃 후 local state 가 항상 클리어되는지 확인
- [ ] OTA 패치 후 24-48h: PICNIC-APP-4XS 신규 이벤트 0 으로 수렴 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)