### PR TITLE
fix(update): App Store launch externalApplication 모드 (PICNIC-APP-4ED)

### DIFF
--- a/picnic_lib/lib/presentation/dialogs/force_update_overlay.dart
+++ b/picnic_lib/lib/presentation/dialogs/force_update_overlay.dart
@@ -45,7 +45,11 @@ class ForceUpdateOverlay extends StatelessWidget {
 
   void _launchAppStore(String url, String message) async {
     if (await canLaunchUrlString(url)) {
-      await launchUrlString(url);
+      // App Store / Play Store URL 은 externalApplication 으로 열어야 OS 가
+      // 외부 스토어 앱으로 deep-link 함. platformDefault(iOS = SFSafariView
+      // Controller) 는 store URL 인텐트 미스매치로 _failedSafariViewController
+      // LoadException 을 던짐 (PICNIC-APP-4ED: 169u/330e).
+      await launchUrlString(url, mode: LaunchMode.externalApplication);
     } else {
       throw message;
     }

--- a/picnic_lib/lib/presentation/dialogs/update_dialog.dart
+++ b/picnic_lib/lib/presentation/dialogs/update_dialog.dart
@@ -77,7 +77,9 @@ class _UpdateDialogState extends ConsumerState<UpdateDialog> {
 
   void _launchAppStore(String url, message) async {
     if (await canLaunchUrlString(url)) {
-      await launchUrlString(url);
+      // App Store / Play Store URL 은 externalApplication 으로 열어야 OS 가
+      // 외부 스토어 앱으로 deep-link 함 (PICNIC-APP-4ED 참고).
+      await launchUrlString(url, mode: LaunchMode.externalApplication);
     } else {
       throw message;
     }


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-4ED](https://icon-casting.sentry.io/issues/PICNIC-APP-4ED)** (169u/330e) — iOS 에서 \`launchUrlString(url)\` 의 \`platformDefault\` 모드가 \`apps.apple.com\` URL 을 SFSafariViewController in-app 으로 띄우려다 실패 → \`PlatformException(_failedSafariViewControllerLoadException)\`.

## Fix
\`force_update_overlay.dart\` + \`update_dialog.dart\` 두 곳의 \`_launchAppStore\` 를 \`LaunchMode.externalApplication\` 으로 변경. OS 가 외부 App Store 앱으로 deep-link.

## Test plan
- [ ] iOS 에서 force-update 시 App Store 앱으로 정상 이동 확인
- [ ] OTA 패치 후 24-48h: PICNIC-APP-4ED 신규 이벤트 0 으로 수렴 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)