### PR TITLE
fix(sentry): User is banned filter (PICNIC-APP-4RJ)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -186,6 +186,14 @@ class AppInitializerHelper {
       return true;
     }
 
+    // User is banned (어드민 정책 차단) — UI 가 차단 안내 후 흐름 종료하는
+    // 정상 응답. 차단 사용자가 재로그인을 시도할 때마다 누적 (PICNIC-APP-4RJ).
+    if (exceptionType == 'AuthApiException' &&
+        (exceptionValue.contains('User is banned') ||
+            exceptionValue.contains('user_banned'))) {
+      return true;
+    }
+
     // Auth session missing — refreshSession() 호출 시 세션이 없는 정상 상태.
     // attendance 등 인증 필요 API 에서 401/403 → 세션 갱신 시도 → 세션 부재로
     // 401 → 사용자에게 재로그인 안내하는 self-healing 흐름의 일부 (PICNIC-APP-508).

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -700,8 +700,11 @@ void main() {
         );
       });
 
-      test('still does NOT filter actionable AuthApiException — e.g. '
-          'user_banned should surface (handled separately, not noise)', () {
+      test('filters AuthApiException(User is banned) — admin policy block, '
+          'UI handles it (PICNIC-APP-4RJ: 39u/183e accumulated)', () {
+        // 이전 결정 (NOT filter, "handled separately") 은 실제 누적 데이터로
+        // 뒤집힘 — UI 가 user_banned 안내 후 종료하는 정상 흐름이므로 Sentry
+        // 노이즈로 처리.
         expect(
           AppInitializerHelper.shouldFilterSentryEvent(
             sentryEnabled: true,
@@ -709,6 +712,20 @@ void main() {
             exceptionType: 'AuthApiException',
             exceptionValue: 'AuthApiException(message: User is banned, '
                 'statusCode: 403, code: user_banned)',
+          ),
+          isTrue,
+        );
+      });
+
+      test('still does NOT filter unrelated AuthApiException — e.g. real '
+          'authorization bug should surface', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'AuthApiException',
+            exceptionValue: 'AuthApiException(message: '
+                'something_unexpected, statusCode: 500)',
           ),
           isFalse,
         );


### PR DESCRIPTION
## Summary
Sentry **[PICNIC-APP-4RJ](https://icon-casting.sentry.io/issues/PICNIC-APP-4RJ)** (39u/183e) — \`AuthApiException(User is banned, code: user_banned)\`. 어드민 정책으로 차단된 사용자가 재로그인 시도 시 발생하는 정상 비즈니스 응답.

이전 결정 (\`"handled separately, not noise"\`) 은 실제 누적 데이터로 뒤집힘 — UI 가 차단 안내 후 종료하므로 노이즈.

## Test plan
- [x] 102 tests pass (\`isFalse → isTrue\` + 회귀 보호 1건 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)