### PR TITLE
fix(sentry): App Hanging/ANR 의 광고 SDK culprit filter

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -104,10 +104,16 @@ class AppInitializer {
       options.captureNativeFailedRequests = false;
 
       options.beforeSend = (event, hint) {
-        final exceptionValue =
-            event.exceptions?.firstOrNull?.value ?? '';
-        final exceptionType =
-            event.exceptions?.firstOrNull?.type ?? '';
+        final exception = event.exceptions?.firstOrNull;
+        final exceptionValue = exception?.value ?? '';
+        final exceptionType = exception?.type ?? '';
+
+        // App Hanging / ANR culprit 매칭용 — stack 의 광고 SDK frame 검출
+        // (PICNIC-APP-45E/45S/56S 등의 PAG/GAD/Tapjoy/Branch 노이즈 차단).
+        final stackFrameFunctions = exception?.stackTrace?.frames
+                .map((f) => f.function ?? '')
+                .toList() ??
+            const <String>[];
 
         // Reactive ACCOUNT_DELETED handling: any Edge Function 403 with
         // code ACCOUNT_DELETED triggers a one-shot local sign-out so the
@@ -126,6 +132,7 @@ class AppInitializer {
           isDebugMode: kDebugMode,
           exceptionType: exceptionType,
           exceptionValue: exceptionValue,
+          stackFrameFunctions: stackFrameFunctions,
         );
 
         return shouldFilter ? null : event;

--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -16,6 +16,7 @@ class AppInitializerHelper {
     required bool isDebugMode,
     required String exceptionType,
     required String exceptionValue,
+    List<String> stackFrameFunctions = const [],
   }) {
     // Drop everything when Sentry is disabled or in debug mode
     if (!sentryEnabled || isDebugMode) {
@@ -201,6 +202,38 @@ class AppInitializerHelper {
       return true;
     }
 
+    // App Hanging / ANR 의 stack 에 광고 SDK frame 이 있는 경우 — Pangle/
+    // Tapjoy/AdMob/Branch SDK 가 main thread 를 차단하는 케이스. 우리가 직접
+    // 호출하는 코드 경로가 아닌 SDK 내부 main loop / lifecycle 콜백에서 발생.
+    // 우리 코드 자체의 hang 은 그대로 추적해야 하므로 stack 매칭 기반으로
+    // 정확히 광고 SDK culprit 만 drop.
+    if ((exceptionType == 'App Hanging' ||
+            exceptionType == 'ApplicationNotResponding') &&
+        _hasAdSdkFrame(stackFrameFunctions)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /// 광고 SDK 의 internal frame prefix 매칭 — App Hanging/ANR culprit 검사용.
+  static bool _hasAdSdkFrame(List<String> frames) {
+    const adSdkPatterns = [
+      'PAG', // Pangle (TikTok ByteDance SDK) - PAGWebView/PAGLBase/PAGDevice
+      'GAD_', // Google AdMob native helpers (GAD_GADAudioSession 등)
+      'GADAudio',
+      'GADRewarded',
+      'GADInterstitial',
+      'Tapjoy',
+      'TJPlacement',
+      'Branch', // Branch SDK (BranchLogger, BranchSDK 등)
+      'bytedance', // Pangle internal modules
+    ];
+    for (final fn in frames) {
+      for (final pattern in adSdkPatterns) {
+        if (fn.contains(pattern)) return true;
+      }
+    }
     return false;
   }
 

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -700,6 +700,101 @@ void main() {
         );
       });
 
+      // -------- App Hanging / ANR with ad SDK culprit --------
+
+      test('filters App Hanging when stack has Pangle (PAG) frame', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'App Hanging',
+            exceptionValue: 'App hanging for at least 2000 ms.',
+            stackFrameFunctions: const [
+              'start',
+              '_pthread_start',
+              '-[PAGWebViewControllerViewModel handleWebViewWebContentProcessDidTerminate:]',
+            ],
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters App Hanging when stack has AdMob (GAD_) frame', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'App Hanging',
+            exceptionValue: 'App hanging for at least 2000 ms.',
+            stackFrameFunctions: const [
+              'GAD_GADAudioSession_arm64_12_2_0',
+            ],
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters App Hanging when stack has Tapjoy frame', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'App Hanging',
+            exceptionValue: 'App hanging for at least 2000 ms.',
+            stackFrameFunctions: const [
+              '-[TJPlacementManager requestContent:]',
+            ],
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters ApplicationNotResponding when stack has Branch frame', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'ApplicationNotResponding',
+            exceptionValue: 'ANR',
+            stackFrameFunctions: const [
+              '-[BranchLogger callingClass]',
+            ],
+          ),
+          isTrue,
+        );
+      });
+
+      test('does NOT filter App Hanging when stack has only our code '
+          '(real hang in our code should surface)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'App Hanging',
+            exceptionValue: 'App hanging for at least 2000 ms.',
+            stackFrameFunctions: const [
+              '_VoteHomePageState._fetch',
+              'PostgrestBuilder.then',
+            ],
+          ),
+          isFalse,
+        );
+      });
+
+      test('does NOT filter non-hang exception even if PAG in stack '
+          '(회귀 보호: hang/ANR 만 ad SDK frame 기반 필터)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'TypeError',
+            exceptionValue: 'something else',
+            stackFrameFunctions: const ['PAGSomething'],
+          ),
+          isFalse,
+        );
+      });
+
       test('filters AuthApiException(User is banned) — admin policy block, '
           'UI handles it (PICNIC-APP-4RJ: 39u/183e accumulated)', () {
         // 이전 결정 (NOT filter, "handled separately") 은 실제 누적 데이터로


### PR DESCRIPTION
## Summary
App Hanging / ANR 누적 이슈 14건 (200+ users 합) 의 culprit 대부분이 광고 SDK main-thread blocking — Pangle/Tapjoy/AdMob/Branch SDK 내부 main loop. 우리 코드 처리 불가능.

## Fix
\`AppInitializerHelper.shouldFilterSentryEvent\` 에 optional \`stackFrameFunctions\` 추가:
- exception type = \`App Hanging\` / \`ApplicationNotResponding\`
- + stack frame function 에 \`PAG\` / \`GAD_\` / \`Tapjoy\` / \`Branch\` / \`bytedance\` 매칭
- → drop

\`beforeSend\` 에서 \`exception.stackTrace.frames.map((f) => f.function)\` 전달.

## Why this is safe
- 우리 코드 culprit hang 은 그대로 캡쳐 (회귀 보호 테스트)
- non-hang exception 은 ad SDK frame 이 있어도 통과 (회귀 보호 테스트)
- 기존 helper caller 영향 없음 (optional default \`const []\`)

## Test plan
- [x] 108 tests pass (6 신규)
- [ ] OTA 패치 후 24-48h: App Hanging/ANR 신규 이벤트 광고 SDK 비중 0 으로 수렴
- [ ] 우리 코드 hang 은 여전히 캡쳐되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)