### PR TITLE
fix(search): 검색/선택에서 soft-deleted 아티스트 제외

### DIFF
--- a/picnic_lib/lib/core/services/search_service.dart
+++ b/picnic_lib/lib/core/services/search_service.dart
@@ -133,7 +133,8 @@ class SearchService {
             'id,name,image,gender,birth_date,is_kpop,artist_group(id,name,image),artist_user_bookmark!left(artist_id)',
           )
           .neq('id', 0) // artist id 0 제외
-          .eq('is_kpop', true); // K-pop 아티스트만 검색
+          .eq('is_kpop', true) // K-pop 아티스트만 검색
+          .isFilter('deleted_at', null); // soft-deleted 아티스트 제외
 
       // 한국어 초성 검색인 경우 모든 아티스트를 가져와서 로컬 필터링
       if (isKoreanInitials) {
@@ -192,7 +193,8 @@ class SearchService {
               'id,name,image,gender,birth_date,is_kpop,artist_group(id,name,image),artist_user_bookmark!left(artist_id)',
             )
             .neq('id', 0)
-            .eq('is_kpop', true); // K-pop 아티스트만 검색
+            .eq('is_kpop', true) // K-pop 아티스트만 검색
+            .isFilter('deleted_at', null); // soft-deleted 아티스트 제외
 
         // 검색어가 있는 경우에만 필터 적용
         if (query.isNotEmpty) {
@@ -219,6 +221,7 @@ class SearchService {
             var groupQuery = supabase
                 .from('artist_group')
                 .select('id,name,image')
+                .isFilter('deleted_at', null) // soft-deleted 그룹 제외
                 .or(
                   'name->>ko.ilike.%$query%,name->>en.ilike.%$query%,name->>ja.ilike.%$query%,name->>zh_CN.ilike.%$query%',
                 );
@@ -242,6 +245,7 @@ class SearchService {
                   )
                   .neq('id', 0)
                   .eq('is_kpop', true) // K-pop 아티스트만 검색
+                  .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
                   .filter('artist_group.id', 'in', matchingGroupIds);
 
               // 제외할 ID가 있는 경우
@@ -349,7 +353,7 @@ class SearchService {
           // 1. 북마크된 아티스트 먼저 가져오기
           final bookmarkedResponse = await supabase
               .from('artist_user_bookmark')
-              .select('artist:artist_id($selectFields)')
+              .select('artist:artist_id($selectFields,deleted_at)')
               .order('created_at', ascending: false);
 
           final bookmarkedArtists = (bookmarkedResponse as List<dynamic>)
@@ -359,7 +363,8 @@ class SearchService {
                 artistData['isBookmarked'] = true;
                 return ArtistModel.fromJson(artistData);
               })
-              .where((artist) => artist.id != 0)
+              // soft-deleted 아티스트는 북마크 목록에서도 제외
+              .where((artist) => artist.id != 0 && artist.deletedAt == null)
               .toList();
 
           results.addAll(bookmarkedArtists);
@@ -373,7 +378,8 @@ class SearchService {
                 .from('artist')
                 .select(selectFields)
                 .neq('id', 0)
-                .eq('is_kpop', true);
+                .eq('is_kpop', true)
+                .isFilter('deleted_at', null); // soft-deleted 아티스트 제외
 
             if (bookmarkedIds.isNotEmpty) {
               generalQuery = generalQuery.not('id', 'in', bookmarkedIds);
@@ -417,7 +423,8 @@ class SearchService {
                 .from('artist')
                 .select(selectFields)
                 .neq('id', 0)
-                .eq('is_kpop', true);
+                .eq('is_kpop', true)
+                .isFilter('deleted_at', null); // soft-deleted 아티스트 제외
 
             if (bookmarkedIds.isNotEmpty) {
               query = query.not('id', 'in', bookmarkedIds);
@@ -437,6 +444,7 @@ class SearchService {
                 .select(selectFields)
                 .neq('id', 0)
                 .eq('is_kpop', true)
+                .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
                 .order('name->>$language', ascending: true)
                 .range(page * limit, (page + 1) * limit - 1);
           }
@@ -467,6 +475,7 @@ class SearchService {
             .select(selectFields)
             .neq('id', 0)
             .eq('is_kpop', true)
+            .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
             .order('name->>$language', ascending: true);
 
         final allArtists = (response as List<dynamic>)
@@ -504,6 +513,7 @@ class SearchService {
           .select(selectFields)
           .neq('id', 0)
           .eq('is_kpop', true)
+          .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
           .or('name->>ko.ilike.$searchPattern,name->>en.ilike.$searchPattern')
           .order('name->>$language', ascending: true)
           .range(page * limit, (page + 1) * limit - 1);

--- a/picnic_lib/test/core/services/search_service_deleted_at_test.dart
+++ b/picnic_lib/test/core/services/search_service_deleted_at_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:picnic_lib/core/services/search_service.dart';
+import 'package:picnic_lib/supabase_options.dart';
+
+/// Regression test for soft-deleted artists leaking into candidate/search
+/// results (e.g. duplicate "이채영" where the corrected entry was soft-deleted
+/// but kept showing up in 투표 후보 신청 / artist search).
+///
+/// The shared mock returns every row regardless of query params, so these
+/// tests assert at the PostgREST request level that every artist search /
+/// selection query carries the `deleted_at=is.null` filter.
+void main() {
+  group('SearchService excludes soft-deleted artists from search/selection', () {
+    late List<Uri> requests;
+
+    setUp(() {
+      SearchService.clearAllCache();
+      requests = [];
+      final mockClient = MockClient((request) async {
+        final uri = request.url;
+        if (uri.path.contains('/rest/v1/')) {
+          requests.add(uri);
+        }
+        return http.Response(
+          '[]',
+          200,
+          request: request,
+          headers: {
+            'content-type': 'application/json',
+            'content-range': '0-0/*',
+          },
+        );
+      });
+      testSupabaseClient = SupabaseClient(
+        'http://localhost:54321',
+        'test-anon-key-for-testing-purposes-only',
+        httpClient: mockClient,
+        authOptions: const AuthClientOptions(autoRefreshToken: false),
+      );
+    });
+
+    tearDown(() {
+      testSupabaseClient = null;
+      SearchService.clearAllCache();
+    });
+
+    List<Uri> requestsForTable(String table) => requests
+        .where((u) => u.path.split('/rest/v1/').last == table)
+        .toList();
+
+    bool allFilterDeletedAt(List<Uri> uris) =>
+        uris.isNotEmpty && uris.every((u) => u.query.contains('deleted_at=is.null'));
+
+    test('searchArtistsFast text search filters deleted_at (reported bug)',
+        () async {
+      await SearchService.searchArtistsFast(query: '이채영');
+
+      final artistReqs = requestsForTable('artist');
+      expect(artistReqs, isNotEmpty,
+          reason: 'a query against the artist table should be issued');
+      expect(allFilterDeletedAt(artistReqs), isTrue,
+          reason: 'artist candidate search must exclude soft-deleted artists');
+    });
+
+    test('searchArtistsFast empty query (default list) filters deleted_at',
+        () async {
+      await SearchService.searchArtistsFast(query: '');
+
+      expect(allFilterDeletedAt(requestsForTable('artist')), isTrue,
+          reason: 'default artist list must exclude soft-deleted artists');
+    });
+
+    test('searchArtists name search filters deleted_at', () async {
+      await SearchService.searchArtists(query: 'Jimin', useCache: false);
+
+      expect(allFilterDeletedAt(requestsForTable('artist')), isTrue,
+          reason: 'artist name search must exclude soft-deleted artists');
+    });
+
+    test('searchArtists Korean-initial search filters deleted_at', () async {
+      await SearchService.searchArtists(
+        query: 'ㅈ',
+        useCache: false,
+        supportKoreanInitials: true,
+      );
+
+      expect(allFilterDeletedAt(requestsForTable('artist')), isTrue,
+          reason: 'Korean-initial artist search must exclude soft-deleted '
+              'artists (it fetches the full list before local filtering)');
+    });
+
+    test('searchArtists group search excludes deleted groups and artists',
+        () async {
+      await SearchService.searchArtists(query: 'aespa', useCache: false);
+
+      expect(allFilterDeletedAt(requestsForTable('artist_group')), isTrue,
+          reason: 'group-name search must exclude soft-deleted groups');
+      expect(allFilterDeletedAt(requestsForTable('artist')), isTrue,
+          reason: 'artists fetched by group must exclude soft-deleted artists');
+    });
+  });
+}


### PR DESCRIPTION
## 문제
투표 후보 신청·아티스트 검색에서 **삭제된(soft-deleted) 아티스트가 노출**됨. 이름 중복 보정으로 구 entry 를 `deleted_at` 처리해도 검색에 계속 떠서 사용자가 잘못된 아티스트를 신청 가능.

예) `이채영` id **1226** (2025-11-05 삭제) 이 활성 entry id **3035** 와 함께 검색 노출.

## 원인
`SearchService.searchArtists()` / `searchArtistsFast()` 의 아티스트·그룹 검색 쿼리가 `deleted_at IS NULL` 을 거르지 않음.

## 변경
검색/선택 경로 11곳에 `.isFilter('deleted_at', null)` 추가:
- 이름 검색, 한글 초성 검색, 그룹명 검색(그룹 자체 + 그룹 소속 아티스트)
- 빈 검색 기본 목록, 북마크 우선표시 목록

## 의도적으로 제외 (회귀 방지)
과거 조인 표시(투표 결과/기록·보드)는 필터 미적용. **살아있는 `vote_item` 4,293개가 이미 삭제된 아티스트를 참조** 중이고 cascade 가 불완전해서, 여기 필터를 걸면 과거 투표 후보가 사라지고 `vote_total` 집계가 바뀜.

## 테스트
- 신규 회귀 테스트 `search_service_deleted_at_test.dart`: 수정 전 5개 실패 → 수정 후 통과
- 기존 포함 search 테스트 142개 전부 통과, `flutter analyze` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)