### PR TITLE
feat(anti-abuse): X-Device-Id 헤더 전송 (attendance/ad/artist-request)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -75,6 +75,32 @@ class AppInitializerHelper {
       return true;
     }
 
+    // FunctionException wrapping a user-side network drop / DNS failure
+    // (PICNIC-APP-4ZY in 1.2.28 patch=4: status 500 with NetworkError /
+    // ClientException / SocketException: Failed host lookup payloads).
+    // The wire-level failure is rendered into the message body, not the
+    // status, so the status-based filter above misses it.
+    if (exceptionType == 'FunctionException' &&
+        (exceptionValue.contains('NetworkError') ||
+            exceptionValue.contains('SocketException') ||
+            exceptionValue.contains('Failed host lookup') ||
+            exceptionValue.contains('Connection closed') ||
+            exceptionValue.contains('Connection reset') ||
+            exceptionValue.contains('Connection terminated') ||
+            exceptionValue.contains('HandshakeException'))) {
+      return true;
+    }
+
+    // Attendance: ALREADY_CHECKED is a normal business-rule response
+    // (user already checked in today). The Edge Function returns 409 to
+    // signal it; supabase_flutter throws FunctionException before the
+    // client can read the body. checkIn() handles it as success — drop
+    // the Sentry noise (PICNIC-APP-4ZX in 1.2.28 patch=4).
+    if (exceptionType == 'FunctionException' &&
+        exceptionValue.contains('ALREADY_CHECKED')) {
+      return true;
+    }
+
     // RLS policy violation noise (PICNIC-APP-47)
     if (exceptionType == 'PostgrestException' &&
         exceptionValue.contains('row-level security policy')) {

--- a/picnic_lib/lib/data/repositories/vote_item_request_repository.dart
+++ b/picnic_lib/lib/data/repositories/vote_item_request_repository.dart
@@ -1,3 +1,4 @@
+import 'package:picnic_lib/core/services/device_manager.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/data/models/vote/vote_item_request_user.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -104,22 +105,59 @@ class VoteItemRequestRepository {
   }
 
   /// 투표 아이템 요청과 사용자 정보를 함께 생성
+  ///
+  /// `artist-request-add` Edge Function 을 통해 anti-abuse 체크 후 요청을 처리합니다.
+  /// X-Device-Id 헤더를 함께 전송합니다 (디바이스 ID 취득 실패 시 헤더 없이 진행).
   Future<Map<String, dynamic>> createVoteItemRequestWithUser({
     required int voteId,
     required int artistId,
     required String userId,
   }) async {
     try {
-      final response = await _supabase.rpc(
-        'create_vote_item_request_with_user',
-        params: {
-          'vote_id_param': voteId,
-          'artist_id_param': artistId,
-          'user_id_param': userId,
+      // Attach X-Device-Id for anti-abuse device-cohort signal.
+      // Graceful: if retrieval fails the request proceeds without the header.
+      Map<String, String>? extraHeaders;
+      try {
+        final deviceId = await DeviceManager.getDeviceId();
+        extraHeaders = {'X-Device-Id': deviceId};
+      } catch (e) {
+        logger.w('Could not retrieve device ID for artist-request-add header: $e');
+      }
+
+      final fnResponse = await _supabase.functions.invoke(
+        'artist-request-add',
+        body: {
+          'vote_id': voteId,
+          'artist_id': artistId,
         },
+        headers: extraHeaders,
       );
 
-      return response as Map<String, dynamic>;
+      final raw = fnResponse.data;
+      final parsed = raw is Map<String, dynamic> ? raw : <String, dynamic>{};
+      if (parsed['success'] != true) {
+        final errorMap = parsed['error'];
+        final code = errorMap is Map ? errorMap['code'] as String? : null;
+        final message = errorMap is Map
+            ? errorMap['message'] as String? ?? '투표 아이템 요청 생성 실패'
+            : '투표 아이템 요청 생성 실패';
+        if (code == 'ALREADY_REQUESTED') {
+          throw const DuplicateVoteRequestException('이미 해당 아티스트에 대해 신청하셨습니다.');
+        }
+        if (code == 'ARTIST_NOT_FOUND') {
+          throw VoteRequestException('존재하지 않는 아티스트입니다.');
+        }
+        if (code == 'RATE_LIMITED') {
+          throw VoteRequestException(message);
+        }
+        throw VoteRequestException(message);
+      }
+
+      return (parsed['data'] as Map<String, dynamic>?) ?? {};
+    } on DuplicateVoteRequestException {
+      rethrow;
+    } on VoteRequestException {
+      rethrow;
     } catch (e) {
       if (e.toString().contains('이미 해당 아티스트에 대해 신청하셨습니다')) {
         throw const DuplicateVoteRequestException('이미 해당 아티스트에 대해 신청하셨습니다.');

--- a/picnic_lib/lib/presentation/providers/attendance_provider.dart
+++ b/picnic_lib/lib/presentation/providers/attendance_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:picnic_lib/core/services/device_manager.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/presentation/providers/attendance_models.dart';
 import 'package:picnic_lib/supabase_options.dart';
@@ -206,10 +207,21 @@ class Attendance extends _$Attendance {
     required bool isRetry,
     void Function()? onAlreadyChecked,
   }) async {
+    // Attach X-Device-Id header for anti-abuse device-cohort signal.
+    // Graceful: if retrieval fails the request proceeds without the header.
+    Map<String, String>? extraHeaders;
+    try {
+      final deviceId = await DeviceManager.getDeviceId();
+      extraHeaders = {'X-Device-Id': deviceId};
+    } catch (e) {
+      logger.w('Could not retrieve device ID for attendance-check header: $e');
+    }
+
     final response = await supabase.functions.invoke(
       'attendance-check',
       method: method,
       body: body,
+      headers: extraHeaders,
     );
 
     final raw = response.data;

--- a/picnic_lib/lib/presentation/providers/attendance_provider.dart
+++ b/picnic_lib/lib/presentation/providers/attendance_provider.dart
@@ -123,6 +123,24 @@ class Attendance extends _$Attendance {
         totalReward: data['totalReward'] as int,
       );
     } on FunctionException catch (e, s) {
+      // 409 + ALREADY_CHECKED is a normal business response (user already
+      // checked in today), but supabase_flutter throws before _invokeAndParse
+      // can inspect the body. Re-route to the success path so the state
+      // flips to checked and Sentry stays quiet (PICNIC-APP-4ZX).
+      if (e.status == 409 && _isAlreadyCheckedException(e)) {
+        final current = state.value;
+        if (current != null) {
+          state = AsyncValue.data(
+            AttendanceState(
+              weeklyStatus: current.weeklyStatus,
+              todayChecked: true,
+              serverTimeKST: current.serverTimeKST,
+              deadlineKST: current.deadlineKST,
+            ),
+          );
+        }
+        return null;
+      }
       logger.e('FunctionException during check-in', error: e, stackTrace: s);
       if (!isRetry && (e.status == 401 || e.status == 403)) {
         if (await _tryRefreshSession('checkIn')) {
@@ -271,6 +289,15 @@ class Attendance extends _$Attendance {
         }
       },
     );
+  }
+
+  bool _isAlreadyCheckedException(FunctionException e) {
+    final details = e.details;
+    if (details is Map) {
+      final error = details['error'];
+      if (error is Map && error['code'] == 'ALREADY_CHECKED') return true;
+    }
+    return e.toString().contains('ALREADY_CHECKED');
   }
 
   bool _isAuthError(Object e) {

--- a/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/platforms/shortform_internal_platform.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/platforms/shortform_internal_platform.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/material.dart';
+import 'package:picnic_lib/core/services/device_manager.dart';
 import 'package:picnic_lib/presentation/widgets/vote/store/free_charge_station/ad_platform.dart';
 import 'package:picnic_lib/supabase_options.dart';
 import 'package:video_player/video_player.dart';
@@ -119,13 +120,24 @@ class ShortformInternalPlatform extends AdPlatform {
               logInfo('loadAd: issuing new tokens');
               final supabaseUrl = Environment.supabaseUrl;
               final token = supabase.auth.currentSession?.accessToken ?? '';
+              // Attach X-Device-Id for anti-abuse device-cohort signal.
+              // Graceful: if retrieval fails the request proceeds without the header.
+              final Map<String, String> issueHeaders = {
+                'Authorization': 'Bearer $token',
+              };
+              try {
+                final deviceId = await DeviceManager.getDeviceId();
+                issueHeaders['X-Device-Id'] = deviceId;
+              } catch (e) {
+                logWarning('Could not retrieve device ID for ad-shortform-issue header: $e');
+              }
               final res =
                   await SupabaseClient(
                     supabaseUrl,
                     Environment.supabaseAnonKey,
                   ).functions.invoke(
                     'ad-shortform-issue',
-                    headers: {'Authorization': 'Bearer $token'},
+                    headers: issueHeaders,
                   );
               if (res.data == null) {
                 throw Exception('issue failed');
@@ -157,11 +169,22 @@ class ShortformInternalPlatform extends AdPlatform {
     try {
       final supabaseUrl = Environment.supabaseUrl;
       final token = supabase.auth.currentSession?.accessToken ?? '';
+      // Attach X-Device-Id for anti-abuse device-cohort signal.
+      // Graceful: if retrieval fails the request proceeds without the header.
+      final Map<String, String> reissueHeaders = {
+        'Authorization': 'Bearer $token',
+      };
+      try {
+        final deviceId = await DeviceManager.getDeviceId();
+        reissueHeaders['X-Device-Id'] = deviceId;
+      } catch (e) {
+        logWarning('Could not retrieve device ID for ad-shortform-issue reissue header: $e');
+      }
       final res = await SupabaseClient(supabaseUrl, Environment.supabaseAnonKey)
           .functions
           .invoke(
             'ad-shortform-issue',
-            headers: {'Authorization': 'Bearer $token'},
+            headers: reissueHeaders,
           );
       if (res.data == null) throw Exception('issue failed');
       final json = res.data as Map<String, dynamic>;

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -390,6 +390,66 @@ void main() {
         );
       });
 
+      // -------- 1.2.28 patch=4 prod sample (PICNIC-APP-4ZY/4ZX) --------
+
+      test('filters FunctionException 500 wrapping NetworkError + '
+          'Failed host lookup (PICNIC-APP-4ZY patch=4)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 500, details: '
+                "{error: NetworkError: Network connection error: "
+                "ClientException with SocketException: Failed host lookup: "
+                "'xtijtefcycoeqludlngc.supabase.co' (OS Error: No address "
+                'associated with hostname, errno = 7)})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping Connection closed', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 500, details: '
+                '{error: Connection closed before full header was received})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException wrapping HandshakeException', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 500, details: '
+                '{error: HandshakeException: Connection terminated})',
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters FunctionException ALREADY_CHECKED — normal business '
+          'response, not noise (PICNIC-APP-4ZX patch=4)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'FunctionException',
+            exceptionValue: 'FunctionException(status: 409, details: '
+                '{success: false, error: {message: Already checked in today, '
+                'code: ALREADY_CHECKED}}, reasonPhrase: Conflict)',
+          ),
+          isTrue,
+        );
+      });
+
       // -------- 1.2.28 prod-leak fixes --------
 
       test('filters FunctionException ACCOUNT_DELETED — handled reactively '

--- a/picnic_lib/test/presentation/providers/attendance_provider_auth_test.dart
+++ b/picnic_lib/test/presentation/providers/attendance_provider_auth_test.dart
@@ -447,6 +447,74 @@ void main() {
     });
   });
 
+  group('Attendance provider - authenticated - checkIn 409 ALREADY_CHECKED '
+      '(PICNIC-APP-4ZX patch=4)', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      await setupMockSupabaseWithAuth({
+        'functions:attendance-check:GET': {
+          'success': true,
+          'data': {
+            'weeklyStatus': weeklyStatusJson,
+            'todayChecked': false,
+            'serverTimeKST': '2026-03-11T15:00:00+09:00',
+            'deadlineKST': '2026-03-12T00:00:00+09:00',
+          },
+        },
+        'functions:attendance-check:POST': {
+          'success': false,
+          'error': {
+            'code': 'ALREADY_CHECKED',
+            'message': 'Already checked in today',
+          },
+        },
+      }, userId: 'test-user-id', functionStatusCodes: {
+        'functions:attendance-check:POST': 409,
+      });
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+      tearDownMockSupabase();
+    });
+
+    test('checkIn returns null when server responds 409 ALREADY_CHECKED',
+        () async {
+      container.listen(attendanceProvider, (_, __) {});
+      await container.read(attendanceProvider.future);
+
+      final notifier = container.read(attendanceProvider.notifier);
+      final result = await notifier.checkIn();
+      expect(result, isNull);
+    });
+
+    test('checkIn flips state.todayChecked to true on 409 ALREADY_CHECKED',
+        () async {
+      container.listen(attendanceProvider, (_, __) {});
+      await container.read(attendanceProvider.future);
+
+      final notifier = container.read(attendanceProvider.notifier);
+      await notifier.checkIn();
+
+      final state = container.read(attendanceProvider);
+      expect(state.value!.todayChecked, true);
+    });
+
+    test('checkIn preserves weeklyStatus on 409 ALREADY_CHECKED', () async {
+      container.listen(attendanceProvider, (_, __) {});
+      await container.read(attendanceProvider.future);
+
+      final notifier = container.read(attendanceProvider.notifier);
+      await notifier.checkIn();
+
+      final state = container.read(attendanceProvider);
+      expect(state.value!.weeklyStatus, isNotNull);
+      expect(state.value!.weeklyStatus!.checkedCount, 2);
+    });
+  });
+
   group('Attendance provider - authenticated - checkIn error', () {
     late ProviderContainer container;
 


### PR DESCRIPTION
## 개요
anti-abuse device-cohort 신호용으로 3개 채널 요청에 `X-Device-Id` 헤더(=`DeviceManager.getDeviceId()`, 기존 hw 지문) 전송. 서버(picnic-supabase PR #31)가 이를 device_hash 화해 "한 기기 N계정" farming 탐지.

## 변경 (`c58d1b118`)
- **attendance-check** (`attendance_provider.dart`): invoke 에 X-Device-Id 헤더.
- **ad-shortform-issue** (`shortform_internal_platform.dart`): loadAd + reissue 2곳 헤더 추가.
- **artist-request-add** (`vote_item_request_repository.dart`): 기존 **RPC 직접호출 → edge fn 경유로 전환**(헤더 전송 + anti-abuse 적용). edge fn 은 동일 RPC `create_vote_item_request_with_user` 래퍼라 drop-in. ⚠️ 이제 앱 아티스트 요청도 artist_request anti-abuse(enforce) 적용됨.
- 모든 호출: `getDeviceId()` 실패 시 try/catch 로 헤더 생략 후 정상 진행(graceful).

## 검증
- `flutter analyze`: 신규 이슈 0 (pre-existing 1건만).
- 헤더 없으면(구버전/실패) 서버 no-op → 하위호환.

## 주의
- 서버 PR #31(SQL→edge) 배포 후 효과. device 신호는 정책 threshold 설정 전까지 OFF.
- 실제 유저 반영은 앱 릴리스(Codemagic/스토어) 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)