### PR TITLE
chore(deps): remove unused font_awesome_flutter

### DIFF
--- a/picnic_app/pubspec.lock
+++ b/picnic_app/pubspec.lock
@@ -1122,14 +1122,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  font_awesome_flutter:
-    dependency: transitive
-    description:
-      name: font_awesome_flutter
-      sha256: b9011df3a1fa02993630b8fb83526368cf2206a711259830325bab2f1d2a4eb0
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.12.0"
   freezed:
     dependency: "direct dev"
     description:

--- a/picnic_lib/pubspec.yaml
+++ b/picnic_lib/pubspec.yaml
@@ -50,7 +50,6 @@ dependencies:
   infinite_scroll_pagination: ^5.0.0
   visibility_detector: ^0.4.0+2
   flutter_keyboard_visibility: ^6.0.0
-  font_awesome_flutter: ^10.8.0
   overlay_support: ^2.1.0
 
   bubble_box: ^0.5.3


### PR DESCRIPTION
## 변경
`font_awesome_flutter` 는 `picnic_lib/pubspec.yaml`의 direct 의존성이나 **코드 사용처 0건**(FontAwesomeIcons/FaIcon/import/동적참조 전무, transitive 아님) → 죽은 의존성 제거.

## 효과
- 미사용 Font Awesome 7 폰트(Brands/Free/Solid) 번들 제거 → 앱 용량↓
- **Shorebird 패치 시 "asset changes not included" 경고 해소** (이 폰트가 패치 누락 대상이었음)

## 검증
- `flutter pub get`: `font_awesome_flutter 10.12.0 no longer depended on` (clean resolve)
- `flutter analyze`: 신규 에러 0 (picnic_lib 629·picnic_app 18건 전부 기존 test/integration_test 린트, FA 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)