### PR TITLE
fix(search): PostgREST or() reserved char 처리 (PICNIC-APP-47)

### DIFF
--- a/picnic_lib/lib/core/services/search_service.dart
+++ b/picnic_lib/lib/core/services/search_service.dart
@@ -119,8 +119,9 @@ class SearchService {
     }
 
     try {
-      if (!isValidQuery(query) && query.isNotEmpty) {
-        throw ArgumentError('Invalid search query: $query');
+      if (query.isNotEmpty && !isValidQuery(query)) {
+        // reserved-only query (e.g. ',') 는 PostgREST 를 깨뜨리고 의미 없는 검색.
+        return <ArtistModel>[];
       }
 
       // 한국어 초성 검색인지 확인
@@ -198,8 +199,9 @@ class SearchService {
 
         // 검색어가 있는 경우에만 필터 적용
         if (query.isNotEmpty) {
+          final q = sanitizeForOr(query);
           artistQuery = artistQuery.or(
-            'name->>ko.ilike.%$query%,name->>en.ilike.%$query%,name->>ja.ilike.%$query%,name->>zh_CN.ilike.%$query%',
+            'name->>ko.ilike.%$q%,name->>en.ilike.%$q%,name->>ja.ilike.%$q%,name->>zh_CN.ilike.%$q%',
           );
         }
 
@@ -218,12 +220,13 @@ class SearchService {
         // 2. 그룹명으로 검색 (검색어가 있을 때만, 빈 검색어일 때는 이미 전체 결과가 있으므로 생략)
         if (query.isNotEmpty) {
           try {
+            final q = sanitizeForOr(query);
             var groupQuery = supabase
                 .from('artist_group')
                 .select('id,name,image')
                 .isFilter('deleted_at', null) // soft-deleted 그룹 제외
                 .or(
-                  'name->>ko.ilike.%$query%,name->>en.ilike.%$query%,name->>ja.ilike.%$query%,name->>zh_CN.ilike.%$query%',
+                  'name->>ko.ilike.%$q%,name->>en.ilike.%$q%,name->>ja.ilike.%$q%,name->>zh_CN.ilike.%$q%',
                 );
 
             final groupResponse = await groupQuery.order(
@@ -506,7 +509,11 @@ class SearchService {
       }
 
       // 일반 텍스트 검색: 아티스트 이름으로 검색
-      final searchPattern = '%$query%';
+      if (!isValidQuery(query)) {
+        // reserved-only query 는 PostgREST or() 를 깨뜨리고 의미도 없음
+        return <ArtistModel>[];
+      }
+      final searchPattern = '%${sanitizeForOr(query)}%';
 
       final response = await supabase
           .from('artist')
@@ -605,16 +612,17 @@ class SearchService {
     }
 
     try {
-      if (!isValidQuery(query) && query.isNotEmpty) {
-        throw ArgumentError('Invalid search query: $query');
+      if (query.isNotEmpty && !isValidQuery(query)) {
+        return <T>[];
       }
 
       dynamic queryBuilder = supabase.from(table).select(selectFields);
 
       // 검색어가 있는 경우 지정된 필드들에서 검색
       if (query.isNotEmpty && searchFields.isNotEmpty) {
+        final q = sanitizeForOr(query);
         final searchConditions = searchFields
-            .map((field) => '$field.ilike.%$query%')
+            .map((field) => '$field.ilike.%$q%')
             .join(',');
         queryBuilder = queryBuilder.or(searchConditions);
       }
@@ -695,10 +703,24 @@ class SearchService {
   }
 
   /// 검색어 유효성 검사
+  ///
+  /// 빈 문자열 또는 PostgREST reserved 문자(`,`, `(`, `)`, `:`, `*`)만으로
+  /// 이루어진 검색어는 의미 있는 검색이 아니고 PostgREST `or=(...)` logic tree
+  /// 파서를 깨뜨리므로(PGRST100) 거부한다.
   static bool isValidQuery(String query) {
-    final trimmedQuery = query.trim();
-    return trimmedQuery.isNotEmpty && trimmedQuery.isNotEmpty;
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return false;
+    if (RegExp(r'^[,():*\s]+$').hasMatch(trimmed)) return false;
+    return true;
   }
+
+  /// PostgREST `or=(...)` 인자에 끼워넣을 query 의 reserved 문자를 제거한다.
+  ///
+  /// `,`, `(`, `)` 는 PostgREST logic tree 의 separator/grouping 으로 해석된다.
+  /// 사용자 입력이 그대로 들어가면 `name->>ko.ilike.%,%` 같은 깨진 표현식이 만들어져
+  /// `failed to parse logic tree` (PGRST100) 가 발생한다.
+  static String sanitizeForOr(String value) =>
+      value.replaceAll(RegExp(r'[,()]'), '');
 
   /// 검색어 정규화 (특수문자 제거, 공백 정리 등)
   static String normalizeQuery(String query) {
@@ -805,16 +827,17 @@ class SearchService {
     }
 
     try {
-      if (!isValidQuery(query) && query.isNotEmpty) {
-        throw ArgumentError('Invalid search query: $query');
+      if (query.isNotEmpty && !isValidQuery(query)) {
+        return <T>[];
       }
 
       dynamic queryBuilder = supabase.from(table).select(selectFields);
 
       // 검색어가 있는 경우 커스텀 검색 조건 적용
       if (query.isNotEmpty && searchConditions.isNotEmpty) {
+        final q = sanitizeForOr(query);
         final formattedConditions = searchConditions
-            .map((condition) => condition.replaceAll('{query}', query))
+            .map((condition) => condition.replaceAll('{query}', q))
             .join(',');
         // 괄호 없이 조건들을 직접 전달
         queryBuilder = queryBuilder.or(formattedConditions);
@@ -1034,6 +1057,10 @@ class SearchService {
     }
 
     try {
+      if (!isValidQuery(query)) {
+        return <BoardModel>[];
+      }
+      final q = sanitizeForOr(query);
       // 직접 Supabase 쿼리 사용 (조인된 테이블 검색을 위해)
       final response = await supabase
           .from('boards')
@@ -1041,7 +1068,7 @@ class SearchService {
             'name, board_id, artist_id, description, is_official, features, artist!inner(*, artist_group(*))',
           )
           .or(
-            'name->>ko.ilike.%$query%,name->>en.ilike.%$query%,name->>ja.ilike.%$query%,name->>zh_CN.ilike.%$query%',
+            'name->>ko.ilike.%$q%,name->>en.ilike.%$q%,name->>ja.ilike.%$q%,name->>zh_CN.ilike.%$q%',
           )
           .neq('artist_id', 0)
           .eq('status', 'approved')

--- a/picnic_lib/lib/presentation/providers/community/boards_provider.dart
+++ b/picnic_lib/lib/presentation/providers/community/boards_provider.dart
@@ -156,11 +156,15 @@ class BoardRequestNotifier extends _$BoardRequestNotifier {
 
   Future<BoardModel?> checkDuplicateBoard(String title) async {
     try {
+      // PostgREST or() 의 reserved 문자 (`,`, `(`, `)`) 를 제거.
+      // title 에 `,` 또는 괄호가 있으면 logic tree parse 가 깨진다 (PGRST100).
+      final t = SearchService.sanitizeForOr(title);
+      if (t.trim().isEmpty) return null;
       final response = await supabase
           .from('boards')
           .select()
           .or(
-            'name->>ko.eq.$title,name->>en.eq.$title,name->>ja.eq.$title,name->>zh_CN.eq.$title',
+            'name->>ko.eq.$t,name->>en.eq.$t,name->>ja.eq.$t,name->>zh_CN.eq.$t',
           )
           .maybeSingle();
 

--- a/picnic_lib/lib/presentation/providers/community/post_provider.dart
+++ b/picnic_lib/lib/presentation/providers/community/post_provider.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: strict_top_level_inference
 
 import 'package:flutter/widgets.dart';
+import 'package:picnic_lib/core/services/search_service.dart';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/data/models/community/post.dart';
 import 'package:picnic_lib/data/models/community/post_scrap.dart';
@@ -120,6 +121,11 @@ Future<List<PostModel>?> postsByQuery(
     if (query.isEmpty) {
       return [];
     }
+    // PostgREST or() 의 reserved 문자 제거 — `,` 가 그대로 들어가면 PGRST100.
+    final q = SearchService.sanitizeForOr(query);
+    if (q.trim().isEmpty) {
+      return [];
+    }
 
     // 1. 차단한 사용자 목록 조회
     List<Map<String, dynamic>> blockedResponse = [];
@@ -148,7 +154,7 @@ Future<List<PostModel>?> postsByQuery(
          ''')
         .isFilter('deleted_at', null)
         .isFilter('post_reports', null)
-        .or('title.ilike.%$query%');
+        .or('title.ilike.%$q%');
 
     // 차단된 사용자가 있는 경우에만 필터 적용
     final blockedFilter = PostProviderHelper.buildBlockedUserFilter(blockedUserIds);

--- a/picnic_lib/test/core/services/search_service_test.dart
+++ b/picnic_lib/test/core/services/search_service_test.dart
@@ -107,10 +107,38 @@ void main() {
       expect(SearchService.isValidQuery('  test  '), isTrue);
       expect(SearchService.isValidQuery('한글'), isTrue);
       expect(SearchService.isValidQuery('123'), isTrue);
+      // reserved char 가 포함되어 있어도 의미 있는 텍스트가 함께 있으면 valid
+      expect(SearchService.isValidQuery('foo,bar'), isTrue);
+      expect(SearchService.isValidQuery('(test)'), isTrue);
 
       // Invalid queries
       expect(SearchService.isValidQuery(''), isFalse);
       expect(SearchService.isValidQuery('   '), isFalse);
+      // PICNIC-APP-47: PostgREST reserved char 만으로 이루어진 query 는 reject
+      expect(SearchService.isValidQuery(','), isFalse);
+      expect(SearchService.isValidQuery(',,,'), isFalse);
+      expect(SearchService.isValidQuery('()'), isFalse);
+      expect(SearchService.isValidQuery('( , )'), isFalse);
+      expect(SearchService.isValidQuery(':'), isFalse);
+      expect(SearchService.isValidQuery('*'), isFalse);
+    });
+
+    test('sanitizeForOr 는 PostgREST reserved 문자를 제거한다', () {
+      // 일반 query 는 그대로
+      expect(SearchService.sanitizeForOr('test'), equals('test'));
+      expect(SearchService.sanitizeForOr('한글'), equals('한글'));
+      expect(SearchService.sanitizeForOr(''), equals(''));
+
+      // PICNIC-APP-47: `,`, `(`, `)` 제거
+      expect(SearchService.sanitizeForOr(','), equals(''));
+      expect(SearchService.sanitizeForOr('foo,bar'), equals('foobar'));
+      expect(SearchService.sanitizeForOr('BTS (Bulletproof)'),
+          equals('BTS Bulletproof'));
+      expect(SearchService.sanitizeForOr('(a,b,c)'), equals('abc'));
+
+      // 다른 reserved-looking 문자는 보존 (ilike pattern 의 `%` 등)
+      expect(SearchService.sanitizeForOr('100%'), equals('100%'));
+      expect(SearchService.sanitizeForOr('a.b'), equals('a.b'));
     });
 
     test('normalizeQuery는 쿼리를 정규화해야 함', () {


### PR DESCRIPTION
## Summary

검색창에 `,` (또는 단독 `(`, `)`) 만 입력해도 PostgREST `or=(...)` logic tree
parser 가 깨져 `PGRST100 failed to parse logic tree` 가 발생.

Sentry **PICNIC-APP-47** — first_seen 2024-08-05, **17,269 events / 403 users**.
patch_number 12 (최신) 단말에서도 동일 발생 = OTA로 막을 수 없는 source-level 버그.

## Root cause

```dart
.or('name->>ko.ilike.%$query%,name->>en.ilike.%$query%,...')
```

`query = ","` 가 그대로 string interpolation 으로 들어가면
`or=(name->>ko.ilike.%,%,name->>en.ilike.%,%,...)` 가 만들어지고,
PostgREST 는 `%,%` 의 `,` 를 logic operator separator 로 인식 → parse 실패.

Sentry 메시지 `failed to parse logic tree ((name->>ko.ilike.%,%,name->>en.ilike.%,%))`
가 정확히 이 패턴을 보여줌.

## 변경

- `SearchService.isValidQuery` — reserved-only query (`,`, `()` 등) 거부 + 기존 중복 `isNotEmpty` 제거
- `SearchService.sanitizeForOr` — `,`, `(`, `)` 제거 (public, 외부 provider 도 사용)
- `searchArtists` / `searchArtistsFast` / `searchBoards` / `searchEntities` / `searchEntitiesAdvanced` 의 `.or()` 호출에 sanitize 일괄 적용
- `boards_provider.checkDuplicateBoard` 와 `post_provider.postsByQuery` — user-provided title/query 가 `.or()` 에 그대로 들어가던 동일 패턴 fix
- 기존 dead-code `throw ArgumentError` 는 빈 결과 반환으로 변경 (사용자 경험 + Sentry 노이즈 차단)
- 단위 테스트 추가: reserved-only / mixed reserved+text / 일반 query

## Test plan

- [x] `flutter test test/core/services/search_service_test.dart` — 90 tests pass
- [x] `flutter test test/core/services/search_service_supabase_test.dart` — 48 tests pass
- [x] `flutter analyze` 새 warning 0
- [ ] Shorebird Patch 11 OTA 배포 후 PICNIC-APP-47 신규 이벤트 수렴 모니터링

Fixes PICNIC-APP-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)