### PR TITLE
fix(provider): goonghap_list 의 unmounted ref 차단 (PICNIC-APP-4R8)

### DIFF
--- a/picnic_lib/lib/presentation/providers/community/goonghap_list_provider.dart
+++ b/picnic_lib/lib/presentation/providers/community/goonghap_list_provider.dart
@@ -27,6 +27,8 @@ class GoonghapList extends _$GoonghapList {
     state = state.copyWith(isLoading: true);
     try {
       final items = await _getHistory(page: 0);
+      // async gap 중 provider 가 dispose 되었으면 state 접근 금지 (PICNIC-APP-4R8)
+      if (!ref.mounted) return;
       state = state.copyWith(
         items: items,
         hasMore: items.length >= _pageSize,
@@ -34,6 +36,7 @@ class GoonghapList extends _$GoonghapList {
       );
     } catch (e, s) {
       logger.e('exception:', error: e, stackTrace: s);
+      if (!ref.mounted) return;
       state = state.copyWith(isLoading: false);
       rethrow;
     }
@@ -47,6 +50,7 @@ class GoonghapList extends _$GoonghapList {
       final page = (state.items.length / _pageSize).floor();
       final items = await _getHistory(page: page);
 
+      if (!ref.mounted) return;
       state = state.copyWith(
         items: [...state.items, ...items],
         hasMore: items.length >= _pageSize,
@@ -54,6 +58,7 @@ class GoonghapList extends _$GoonghapList {
       );
     } catch (e, s) {
       logger.e('Error', error: e, stackTrace: s);
+      if (!ref.mounted) return;
       state = state.copyWith(isLoading: false);
       rethrow;
     }


### PR DESCRIPTION
## Summary

`GoonghapList.loadInitial` / `loadMore` 의 `await _getHistory(...)` 가
끝나기 전에 provider 가 dispose 되면, 이후 `state = ...` 가
**UnmountedRefException** 을 throw.

Sentry **PICNIC-APP-4R8** — 27 users / 48 events, **patch_number=10** 단말에서도
발생 (OTA로 fix 가능).

## Root cause

```dart
state = state.copyWith(isLoading: true);
try {
  final items = await _getHistory(page: 0);  // ← provider disposed
  state = state.copyWith(...);               // ← UnmountedRefException
} catch (e, s) {
  state = state.copyWith(isLoading: false);  // ← 또는 여기서 throw
  rethrow;
}
```

## 변경

각 `await` 직후와 catch 의 state 접근 직전에 `if (!ref.mounted) return;` 가드 추가.
기존 PR #22 와 같은 의도지만 widget 의 ref 가 아니라 Notifier 의 ref 이므로
`ProviderScope.containerOf` 가 아닌 `ref.mounted` 사용.

## Test plan

- [x] `flutter test goonghap_list_provider*_test.dart` — 21 tests pass
- [x] `flutter analyze` 0 issues
- [ ] Shorebird Patch 11 OTA 배포 후 PICNIC-APP-4R8 신규 이벤트 수렴 모니터링

Fixes PICNIC-APP-4R8

🤖 Generated with [Claude Code](https://claude.com/claude-code)