### PR TITLE
fix(auth): SecureStorage write 실패 swallow (PICNIC-APP-58P)

### DIFF
--- a/picnic_lib/lib/core/services/secure_storage_service.dart
+++ b/picnic_lib/lib/core/services/secure_storage_service.dart
@@ -21,8 +21,12 @@ class SecureStorageService {
         value: jsonEncode(sessionJson),
       );
     } catch (e, s) {
-      logger.e('Error saving session to storage', error: e, stackTrace: s);
-      rethrow;
+      // Android Keystore 가 일부 단말 (HUAWEI 등) 에서 NPE/PlatformException 을 throw
+      // (PICNIC-APP-58P). SecureStorage 는 SDK 의 SharedPreferences-기반
+      // currentSession 의 backup 일 뿐이라, write 실패로 로그인 흐름을 깰 이유가 없다.
+      // 다음 cold start 시 recoverSession() 이 SDK session 으로 복구한다.
+      logger.w('Failed to persist session to secure storage; SDK session is primary',
+          error: e, stackTrace: s);
     }
   }
 

--- a/picnic_lib/test/core/services/secure_storage_service_test.dart
+++ b/picnic_lib/test/core/services/secure_storage_service_test.dart
@@ -1,6 +1,55 @@
+// ignore_for_file: depend_on_referenced_packages
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:picnic_lib/core/services/secure_storage_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _ThrowingFlutterSecureStoragePlatform extends FlutterSecureStoragePlatform {
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) async =>
+      false;
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) async {}
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async {}
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) async =>
+      null;
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) async =>
+      <String, String>{};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    // PICNIC-APP-58P 의 Android Keystore NPE/PlatformException 시뮬레이션
+    throw PlatformException(
+      code: 'Exception encountered, write',
+      message: "java.lang.NullPointerException: Attempt to invoke virtual method "
+          "'byte[] TF0.a(byte[])' on a null object reference",
+    );
+  }
+}
 
 void main() {
   late FlutterSecureStorage storage;
@@ -138,6 +187,31 @@ void main() {
       final customStorage = const FlutterSecureStorage();
       final customService = SecureStorageService(customStorage);
       expect(customService, isNotNull);
+    });
+  });
+
+  group('SecureStorageService - saveSession 의 keystore 실패 swallow (PICNIC-APP-58P)', () {
+    test('write 가 PlatformException 을 throw 해도 rethrow 하지 않아야 함', () async {
+      // Arrange — 일부 Android 단말의 Keystore NPE 재현
+      FlutterSecureStoragePlatform.instance = _ThrowingFlutterSecureStoragePlatform();
+      final throwingService = SecureStorageService(const FlutterSecureStorage());
+
+      final session = Session.fromJson({
+        'access_token': 'test',
+        'token_type': 'bearer',
+        'expires_in': 3600,
+        'refresh_token': 'test_refresh',
+        'user': {
+          'id': 'u',
+          'app_metadata': <String, dynamic>{},
+          'user_metadata': <String, dynamic>{},
+          'aud': 'authenticated',
+          'created_at': '2024-01-01T00:00:00.000Z',
+        },
+      })!;
+
+      // Act & Assert — rethrow 하지 않고 정상 return
+      await expectLater(throwingService.saveSession(session), completes);
     });
   });
 


### PR DESCRIPTION
## Summary

일부 Android 단말 (HUAWEI Nova 5T 등) 의 **Keystore** 가
`FlutterSecureStorage.write` 호출 시 `NullPointerException` 을 throw,
기존 코드는 rethrow 하면서 **Google 로그인 흐름 전체를 깨뜨림**.

Sentry **PICNIC-APP-58P** — 4 users / 28 events, **patch_number=12 (최신)** 에서도 발생.

## Root cause

Sentry chained stack:
```
PlatformException(Exception encountered, write,
  java.lang.NullPointerException: Attempt to invoke virtual method
  'byte[] TF0.a(byte[])' on a null object reference) ← Android Keystore
  ↑
SecureStorageService.saveSession (line 19) ← rethrow
  ↑
AuthService._saveAndNotifySession (line 296)
  ↑
AuthService.signInWithProvider (line 93)
  ↑
_LoginScreenState._buildGoogleLogin (login_page.dart:604) ← 사용자에게 노출
```

## 변경

`SecureStorage` 는 SDK 의 SharedPreferences-기반 `currentSession` 의 **backup** 일 뿐이라
write 실패가 로그인 흐름을 깰 이유가 없음. catch 에서 rethrow 제거.

```dart
} catch (e, s) {
  logger.w('Failed to persist session to secure storage; '
           'SDK session is primary', error: e, stackTrace: s);
  // rethrow 제거 (PICNIC-APP-58P)
}
```

다음 cold start 시 `recoverSession()` 이 SDK session 으로 복구 — 정상 흐름.

## Test plan

- [x] `flutter test secure_storage_service_test.dart` — 11 tests pass
- [x] 회귀 테스트 추가: `PlatformException` 시뮬레이션 후 `saveSession` 이 `completes`
- [x] `flutter analyze` 0 issues
- [ ] Shorebird Patch 11 OTA 배포 후 PICNIC-APP-58P 신규 이벤트 수렴 모니터링

Fixes PICNIC-APP-58P

🤖 Generated with [Claude Code](https://claude.com/claude-code)