### PR TITLE
fix(sentry): SqfliteDatabaseException 의 storage 환경 노이즈 filter

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -158,6 +158,17 @@ class AppInitializerHelper {
       return true;
     }
 
+    // sqflite cache DB 가 사용자 단말 환경 때문에 실패하는 케이스 (PICNIC-APP-547/52R/52S).
+    // - SQLITE_FULL / 'disk is full' : 디스크 거의 0. cache_store 의 image cache 쓰기 실패.
+    // - 'unable to open database file' : iOS sandbox/권한/디스크 문제 (iPhone 7 등 old device).
+    // 모두 사용자 storage 상태 문제이고 앱이 cache 누락 으로 graceful degrade 됨 — 노이즈.
+    if (exceptionType == 'SqfliteDatabaseException' &&
+        (exceptionValue.contains('SQLITE_FULL') ||
+            exceptionValue.contains('disk is full') ||
+            exceptionValue.contains('unable to open database file'))) {
+      return true;
+    }
+
     // Image picker double-tap (PICNIC-APP-VQ).
     // Plugin throws when the picker is invoked while a previous instance is
     // still mounted — pure UX noise, no app-side fix needed.

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -247,6 +247,46 @@ void main() {
         );
       });
 
+      test('filters SqfliteDatabaseException SQLITE_FULL (PICNIC-APP-547)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'SqfliteDatabaseException',
+            exceptionValue:
+                "DatabaseException(database or disk is full (code 13 SQLITE_FULL)) sql 'UPDATE cacheObject SET ...'",
+          ),
+          isTrue,
+        );
+      });
+
+      test('filters SqfliteDatabaseException unable to open db (PICNIC-APP-52R/52S)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'SqfliteDatabaseException',
+            exceptionValue:
+                'DatabaseException(Error Domain=SqfliteDarwinDatabase Code=14 '
+                '"unable to open database file" ...) sql \'DELETE FROM cacheObject WHERE _id = ?\'',
+          ),
+          isTrue,
+        );
+      });
+
+      test('does not filter SqfliteDatabaseException for unrelated DB error', () {
+        // 다른 DB 에러(예: constraint violation)는 우리 코드의 schema 버그일 수 있어 통과시킨다.
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'SqfliteDatabaseException',
+            exceptionValue: 'UNIQUE constraint failed: cacheObject.url',
+          ),
+          isFalse,
+        );
+      });
+
       // -------- Coverage gap fixes (production-leak issues on 1.2.27) --------
 
       test('filters HttpException as network noise (PICNIC-APP-49W)', () {


### PR DESCRIPTION
## Summary

`cache_store` 의 sqflite UPDATE/DELETE/INSERT 가 사용자 단말의
storage 상태 때문에 실패하는 케이스를 Sentry beforeSend 에서 차단.
앱은 cache miss 로 graceful degrade — 실제 사용자 영향 없음.

| Issue | Pattern | Users / Events | 환경 |
|---|---|---|---|
| **PICNIC-APP-547** | `SQLITE_FULL` / `disk is full` | 2u / 6e | Android, free_storage 8KB |
| **PICNIC-APP-52R** | `unable to open database file` | 4u / 73e | iOS 15, iPhone 7 |
| **PICNIC-APP-52S** | 동일 (INSERT) | 3u / 38e | iOS 15 |

## 변경

`AppInitializerHelper.shouldFilterSentryEvent` 에 패턴 추가:

```dart
if (exceptionType == 'SqfliteDatabaseException' &&
    (exceptionValue.contains('SQLITE_FULL') ||
        exceptionValue.contains('disk is full') ||
        exceptionValue.contains('unable to open database file'))) {
  return true;
}
```

unrelated DB 에러 (예: `UNIQUE constraint`) 는 우리 schema 버그일 수
있으므로 통과시켜 추적 유지.

## Test plan

- [x] `flutter test app_initializer_helper_test.dart` — 111 tests pass (positive 2 + negative 1 추가)
- [x] `flutter analyze` 0 issues
- [ ] 다음 patch deploy 또는 release 사이클에서 547/52R/52S 신규 0 확인 후 resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)