### PR TITLE
fix(sentry): iOS AppHang threshold 2s → 3s (PICNIC-APP-4YV)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -92,6 +92,15 @@ class AppInitializer {
       options.anrEnabled = true;
       options.anrTimeoutInterval = const Duration(seconds: 5);
 
+      // iOS AppHang threshold 를 default 2s → 3s 로 상향 (PICNIC-APP-4YV 등).
+      // 4YV (46u/124e) 의 culprit 이 ChangeNotifier._removeAt, Subtype6TestCache,
+      // DefaultNullableTypeTest, CallBootstrapNative 등으로 매우 분산 — 단일 코드
+      // 버그가 아니라 메모리 부족 iOS 단말(예: iPhone X free_memory 60MB)의 burst
+      // CPU 정체가 다양한 hot path 에서 잡힌 결과. 2s 는 iOS watchdog kill 임계
+      // (~4-6s) 대비 과민 — 3s 는 사용자가 체감하는 freeze 만 추적하면서 노이즈
+      // 큰 폭 감소. 4s+ 는 watchdog 와 가까워 진짜 hang 을 놓칠 위험이 있어 3s 가 균형점.
+      options.appHangTimeoutInterval = const Duration(seconds: 3);
+
       // 네이티브 SDK 의 URLSession/OkHttp 자동 5xx 캡쳐(SentryNetworkTracker)
       // 를 끈다. 이 경로는 Flutter beforeSend 를 우회하므로 광고 SDK
       // (Pangle/AdMob/Branch 등) 의 텔레메트리 5xx 가 그대로 누적된다


### PR DESCRIPTION
## Summary

iOS AppHang detector 의 `appHangTimeoutInterval` 을 default **2s → 3s** 로 상향.
PICNIC-APP-4YV (46u/124e) 의 누적 노이즈를 진짜 사용자 freeze 만으로 좁힘.

## Root cause 분석

4YV 의 14d 윈도우 10 event 의 culprit 분포:

| Culprit | 횟수 | 분류 |
|---|---|---|
| `ChangeNotifier._removeAt` | 3 | widget unmount |
| `Subtype6TestCache` | 3 | Dart runtime type check 캐시 |
| `DefaultNullableTypeTest` | 2 | Dart nullable type check |
| `ChangeNotifier.removeListener` | 1 | widget unmount |
| `CallBootstrapNative` | 1 | Dart VM bootstrap |

- **iOS only** (`mechanism: AppHang`, `event.origin: ios`)
- **user.geo 전부 PH (필리핀)** — 4명 사용자가 반복 발생
- 디바이스: iPhone X / iPhone 11 / iPhone 8+ / iPhone 13 mini
- 4YV sample 의 **free_memory 60MB / 2GB** — 메모리 부족

→ 단일 버그가 아닌 **메모리 부족 iOS 단말의 burst CPU 정체가 다양한 Dart runtime hot path 에서 잡힌 패턴**. 단일 코드 fix 로 해결 불가.

## 변경

```dart
// iOS AppHang threshold 를 default 2s → 3s 로 상향 (PICNIC-APP-4YV).
options.appHangTimeoutInterval = const Duration(seconds: 3);
```

### Threshold 선택 근거

| 값 | 효과 | 리스크 |
|---|---|---|
| 2s (default) | 매우 민감 | 노이즈 대량 발생 (현재 상태) |
| **3s** ✅ | 체감 freeze 만 | 균형점 |
| 4s+ | 더 적은 노이즈 | iOS watchdog kill(~4-6s) 임계 근접 — 진짜 hang 누락 위험 |

## Test plan

- [x] `flutter analyze` — `appHangTimeoutInterval` 옵션 sentry_flutter 8.11 에서 지원 확인
- [ ] Patch 17/18 적용 후 4YV 신규 발생률 감소 확인 (3s 미만 hang drop)
- [ ] 1-2주 후 4YV 자연 수렴 추세 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)