### PR TITLE
fix(sentry): system-only ANR drop (PICNIC-APP-45E/464/4PY)

### DIFF
--- a/picnic_lib/lib/core/utils/app_initializer.dart
+++ b/picnic_lib/lib/core/utils/app_initializer.dart
@@ -124,6 +124,13 @@ class AppInitializer {
                 .toList() ??
             const <String>[];
 
+        // system-only ANR 판별용 — stack 이 전부 system frame (inApp=false) 이면
+        // 우리가 분석할 수 있는 정보가 없는 ANR (PICNIC-APP-45E 등).
+        final stackFrameInApp = exception?.stackTrace?.frames
+                .map((f) => f.inApp ?? false)
+                .toList() ??
+            const <bool>[];
+
         // Reactive ACCOUNT_DELETED handling: any Edge Function 403 with
         // code ACCOUNT_DELETED triggers a one-shot local sign-out so the
         // soft-deleted user stops generating repeated 403s on subsequent
@@ -142,6 +149,7 @@ class AppInitializer {
           exceptionType: exceptionType,
           exceptionValue: exceptionValue,
           stackFrameFunctions: stackFrameFunctions,
+          stackFrameInApp: stackFrameInApp,
         );
 
         return shouldFilter ? null : event;

--- a/picnic_lib/lib/core/utils/app_initializer_helper.dart
+++ b/picnic_lib/lib/core/utils/app_initializer_helper.dart
@@ -17,6 +17,7 @@ class AppInitializerHelper {
     required String exceptionType,
     required String exceptionValue,
     List<String> stackFrameFunctions = const [],
+    List<bool> stackFrameInApp = const [],
   }) {
     // Drop everything when Sentry is disabled or in debug mode
     if (!sentryEnabled || isDebugMode) {
@@ -221,6 +222,19 @@ class AppInitializerHelper {
     if ((exceptionType == 'App Hanging' ||
             exceptionType == 'ApplicationNotResponding') &&
         _hasAdSdkFrame(stackFrameFunctions)) {
+      return true;
+    }
+
+    // system-only ANR — 우리 코드 frame 이 stack 에 단 한 개도 없는 ANR.
+    // (PICNIC-APP-45E 99u/450e, 464 16u/139e, 4PY 6u/15e 등)
+    // mechanism=AppExitInfo 로 Android OS 가 사후 보고하는 ANR 중 stack 이
+    // 전부 android.os.Looper / nativePollOnce / pollInner 같은 system frame 인
+    // 케이스. 우리가 분석/수정 가능한 정보가 0 이라 추적 가치 없음.
+    // 우리 코드 frame 이 있는 ANR (51W WV.mt0 onServiceConnected, 53X scudo
+    // PageReleaseContext 등) 은 그대로 통과시켜 root cause 추적 유지.
+    if (exceptionType == 'ApplicationNotResponding' &&
+        stackFrameInApp.isNotEmpty &&
+        !stackFrameInApp.any((inApp) => inApp)) {
       return true;
     }
 

--- a/picnic_lib/test/core/utils/app_initializer_helper_test.dart
+++ b/picnic_lib/test/core/utils/app_initializer_helper_test.dart
@@ -835,6 +835,65 @@ void main() {
         );
       });
 
+      // -------- system-only ANR (PICNIC-APP-45E 등) --------
+
+      test('filters ApplicationNotResponding with all-system stack frames '
+          '(PICNIC-APP-45E)', () {
+        // 45E sample: TECNO KL5 low-end Android, mechanism=AppExitInfo,
+        // stack 이 전부 android.os.Looper / pollInner / nativePollOnce.
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'ApplicationNotResponding',
+            exceptionValue: 'ANR',
+            stackFrameInApp: const [false, false, false, false, false],
+          ),
+          isTrue,
+        );
+      });
+
+      test('does NOT filter ANR when at least one in-app frame is present '
+          '(우리 코드 frame 있는 ANR 은 root cause 추적 유지)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'ApplicationNotResponding',
+            exceptionValue: 'ANR',
+            stackFrameInApp: const [false, false, true, false],
+          ),
+          isFalse,
+        );
+      });
+
+      test('does NOT filter ANR when stackFrameInApp is empty '
+          '(보수적 통과 — 정보 부족 시 drop 하지 않음)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'ApplicationNotResponding',
+            exceptionValue: 'ANR',
+          ),
+          isFalse,
+        );
+      });
+
+      test('does NOT filter non-ANR exception with all-system frames '
+          '(회귀 보호: ANR 만 system-only 기반 필터)', () {
+        expect(
+          AppInitializerHelper.shouldFilterSentryEvent(
+            sentryEnabled: true,
+            isDebugMode: false,
+            exceptionType: 'TypeError',
+            exceptionValue: 'something',
+            stackFrameInApp: const [false, false, false],
+          ),
+          isFalse,
+        );
+      });
+
       test('filters AuthApiException(User is banned) — admin policy block, '
           'UI handles it (PICNIC-APP-4RJ: 39u/183e accumulated)', () {
         // 이전 결정 (NOT filter, "handled separately") 은 실제 누적 데이터로


### PR DESCRIPTION
## Summary

**Sentry filter 에 system-only ANR drop 추가.** stack frame 이 전부 OS frame
(우리 코드 단 한 개도 없는 ANR) 을 차단 — 우리가 분석할 수 있는 정보가 0.

## 데이터

PICNIC-APP-45E (99u / 450e) 의 14d 윈도우 10 event 분석:

| 속성 | 값 |
|---|---|
| `mechanism` | **AppExitInfo** — Android OS 사후 보고. SDK 가 detect 한 게 아님 |
| `culprit` | `?` |
| `in_app_frame_mix` | `system-only` |
| `device.class` | `low` (TECNO KL5/BF7, RMX3938, CPH2773, SM-A037M) |
| `user.geo` | PH / MX / ID — 신흥시장 + low-end Android |
| Stack | `android::Looper::pollInner` / `MessageQueue.nativePollOnce` only |

→ `anrTimeoutInterval` 조정으로 못 막는다 (AppExitInfo 는 OS 가 직접 보고).
→ 사용자 단말 사양 / 시스템 부하 문제이고 우리가 수정할 정보가 없다.

## 변경

`AppInitializerHelper.shouldFilterSentryEvent` 에 `stackFrameInApp: List<bool>` 파라미터:

```dart
if (exceptionType == 'ApplicationNotResponding' &&
    stackFrameInApp.isNotEmpty &&
    !stackFrameInApp.any((inApp) => inApp)) {
  return true;
}
```

`app_initializer.dart` 의 `beforeSend` 에서 `frames.map((f) => f.inApp ?? false)` 로
inApp 정보 추출해 helper 로 전달.

### 유지되는 케이스 (회귀 보호)

- **51W** ANR `WV.mt0 in onServiceConnected` — 우리 init flow frame 있음 → 통과
- **53X** ANR `scudo::PageReleaseContext` — 메모리 alloc 관련, system frame 도 우리 frame 도 mixed → 통과
- **4YV/4YE 등 App Hanging** — exceptionType 이 `App Hanging` 이지 `ApplicationNotResponding` 아님 → 영향 없음
- 다른 exception 의 all-system stack — guard 절로 통과

## Test plan

- [x] `flutter test app_initializer_helper_test.dart` — **115 tests pass** (positive 1 + negative 3 추가)
- [x] `flutter analyze` 새 warning 0 (기존 `profilesSampleRate` experimental 경고는 무관)
- [ ] Patch 17/18 적용 후 45E / 464 / 4PY 신규 발생률 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)