### PR TITLE
chore(sentry): prod sample_rates 조정 (trace/profile/session 1.0 → 적정)

### DIFF
--- a/picnic_app/config/prod.json
+++ b/picnic_app/config/prod.json
@@ -26,9 +26,9 @@
     "app_dsn": "https://2a10b0168b427bbdc6eb3a1f16a1f2a2@o4507695222685696.ingest.us.sentry.io/4507695242739712",
     "web_dsn": "https://9125a97b1328d1c4b578b69a1a4f4774@o4507695222685696.ingest.us.sentry.io/4507964278046720",
     "sample_rates": {
-      "trace": 1.0,
-      "profile": 1.0,
-      "session": 1.0,
+      "trace": 0.2,
+      "profile": 0.5,
+      "session": 0.3,
       "error": 1.0
     }
   },


### PR DESCRIPTION
## Summary

prod 의 Sentry sample_rate 가 모두 `1.0` (100%) 으로 매우 공격적 — quota / 비용 부담 큼.
권장값으로 조정.

## 데이터

7d 윈도우 picnic-app:

| Dataset | events | 비고 |
|---|---|---|
| `errors` | **620** | filter 활성 후 잔존 노이즈만 — 양 작음 |
| `spans (trace)` | **124,441** | trace=1.0 결과, 월 ~530K |

## 변경 (prod.json 만)

| Sample | 변경 전 | 변경 후 | 이유 |
|---|---|---|---|
| `error` | 1.0 | **1.0** | 양 적고 fix 효과 검증에 필수 |
| `trace` | 1.0 | **0.2** | span 124K → ~25K/7d, 80% 절감 |
| `profile` | 1.0 | **0.5** | sampled trace 의 절반만 profile (effective ~10%) |
| `session` | 1.0 | **0.3** | Session Replay 비용 큼 |

- **dev/local 은 1.0 유지** (개발자 디버깅 우선)

## Test plan

- [ ] PR merge 후 다음 라운드 patch 와 묶어 deploy
- [ ] 7d 후 spans/sessions/profiles 양 관찰 — Sentry quota 사용량 정상화 확인
- [ ] 4YV 등 hang issue 의 profile 첨부 비율 ~10% 로 유지 확인 (분석 가능성 보장)

## Reverts

quota 여유 있는 plan 이거나 더 깊은 분석 필요시 0.5/0.7 등으로 상향 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)