### PR TITLE
fix(vm-detector): systemFeatures 를 deviceInfo 합성에서 제외 (2025-02 FP 회귀 차단)

### DIFF
--- a/picnic_lib/lib/core/utils/virtual_machine_detector.dart
+++ b/picnic_lib/lib/core/utils/virtual_machine_detector.dart
@@ -269,33 +269,75 @@ class VirtualMachineDetector {
     return pattern.hasMatch(text);
   }
 
+  // info.systemFeatures 는 의도적으로 제외.
+  // Samsung 단말의 'com.samsung.android.cloud' 같은 정상 패키지명이
+  // containsWholeToken 의 `.` 경계 처리로 인해 generic 키워드 ('cloud' 등) 에
+  // false-match 하는 사고가 있었음 (2025-02 인시던트, 594/595 FP).
+  // 패키지명 기반 매칭이 필요하면 별도 keyword 리스트 + 정확 매칭으로 분리할 것.
+  @visibleForTesting
+  static String buildDeviceInfoForMatching({
+    required String manufacturer,
+    required String model,
+    required String brand,
+    required String fingerprint,
+    required String product,
+    required String device,
+    required String hardware,
+    required String host,
+    required String board,
+    required String bootloader,
+    required String display,
+    required String id,
+    required String tags,
+    required String type,
+    required List<String> supported32BitAbis,
+    required List<String> supported64BitAbis,
+  }) {
+    return '''
+      $manufacturer
+      $model
+      $brand
+      $fingerprint
+      $product
+      $device
+      $hardware
+      $host
+      $board
+      $bootloader
+      $display
+      $id
+      $tags
+      $type
+      ${supported32BitAbis.join(' ')}
+      ${supported64BitAbis.join(' ')}
+      ${host}_${product}_$device
+      ${brand}_${manufacturer}_$model
+    '''
+        .toLowerCase();
+  }
+
   static Future<BuildCheckResults> _getBuildCheckResults(
     AndroidDeviceInfo info,
     List<String?> configs,
   ) async {
-    final String deviceInfo =
-        '''
-      ${info.manufacturer}
-      ${info.model}
-      ${info.brand}
-      ${info.fingerprint}
-      ${info.product}
-      ${info.device}
-      ${info.hardware}
-      ${info.host}
-      ${info.board}
-      ${info.bootloader}
-      ${info.display}
-      ${info.id}
-      ${info.tags}
-      ${info.type}
-      ${info.supported32BitAbis.join(' ')}
-      ${info.supported64BitAbis.join(' ')}
-      ${info.systemFeatures.join(' ')}
-      ${info.host}_${info.product}_${info.device}
-      ${info.brand}_${info.manufacturer}_${info.model}
-    '''
-            .toLowerCase();
+    final String deviceInfo = buildDeviceInfoForMatching(
+      manufacturer: info.manufacturer,
+      model: info.model,
+      brand: info.brand,
+      fingerprint: info.fingerprint,
+      product: info.product,
+      device: info.device,
+      hardware: info.hardware,
+      host: info.host,
+      board: info.board,
+      bootloader: info.bootloader,
+      display: info.display,
+      id: info.id,
+      tags: info.tags,
+      type: info.type,
+      supported32BitAbis: info.supported32BitAbis,
+      supported64BitAbis: info.supported64BitAbis,
+    );
 
     // 기본 정보 로깅
     logger.d('''

--- a/picnic_lib/test/core/utils/virtual_machine_detector_test.dart
+++ b/picnic_lib/test/core/utils/virtual_machine_detector_test.dart
@@ -111,6 +111,116 @@ void main() {
     });
   });
 
+  group('buildDeviceInfoForMatching', () {
+    // 2025-02 인시던트 회귀 가드:
+    // info.systemFeatures 를 deviceInfo 에 합치면 Samsung 단말의
+    // 'com.samsung.android.cloud' 같은 정상 패키지가 'cloud' 키워드에
+    // whole-token 매치돼서 594/595 FP 발생함.
+    String build({
+      String manufacturer = 'samsung',
+      String model = 'SM-A125F',
+      String brand = 'samsung',
+      String fingerprint =
+          'samsung/a12nnxx/a12:12/SP1A.210812.016/A125FXXS6CXJ1:user/release-keys',
+      String product = 'a12nnxx',
+      String device = 'a12',
+      String hardware = 'mt6765',
+      String host = '21DJ6A01',
+      String board = 'a12',
+      String bootloader = 'A125FXXS6CXJ1',
+      String display = 'SP1A.210812.016.A125FXXS6CXJ1',
+      String id = 'SP1A.210812.016',
+      String tags = 'release-keys',
+      String type = 'user',
+      List<String> supported32BitAbis = const ['armeabi-v7a', 'armeabi'],
+      List<String> supported64BitAbis = const ['arm64-v8a'],
+    }) {
+      return VirtualMachineDetector.buildDeviceInfoForMatching(
+        manufacturer: manufacturer,
+        model: model,
+        brand: brand,
+        fingerprint: fingerprint,
+        product: product,
+        device: device,
+        hardware: hardware,
+        host: host,
+        board: board,
+        bootloader: bootloader,
+        display: display,
+        id: id,
+        tags: tags,
+        type: type,
+        supported32BitAbis: supported32BitAbis,
+        supported64BitAbis: supported64BitAbis,
+      );
+    }
+
+    test('lowercased output', () {
+      expect(build(), equals(build().toLowerCase()));
+    });
+
+    test('includes core build fields', () {
+      final out = build();
+      expect(out, contains('samsung'));
+      expect(out, contains('sm-a125f'));
+      expect(out, contains('mt6765'));
+      expect(out, contains('a125fxxs6cxj1'));
+      expect(out, contains('release-keys'));
+    });
+
+    test('includes compound host_product_device and brand_manufacturer_model',
+        () {
+      final out = build();
+      expect(out, contains('21dj6a01_a12nnxx_a12'));
+      expect(out, contains('samsung_samsung_sm-a125f'));
+    });
+
+    test('includes supported ABIs', () {
+      final out = build(
+        supported32BitAbis: ['armeabi-v7a', 'armeabi'],
+        supported64BitAbis: ['arm64-v8a'],
+      );
+      expect(out, contains('arm64-v8a'));
+      expect(out, contains('armeabi-v7a'));
+    });
+
+    test(
+      'real Samsung Galaxy A12 input does NOT contain "cloud" '
+      '(systemFeatures excluded - regression for 2025-02 FP incident)',
+      () {
+        final out = build();
+        expect(
+          VirtualMachineDetector.containsWholeToken(out, 'cloud'),
+          isFalse,
+          reason:
+              'Samsung 정상 system feature (com.samsung.android.cloud) 가 '
+              'deviceInfo 에 섞이면 "cloud" 키워드가 FP 매치함. '
+              'systemFeatures 를 deviceInfo 합성에서 제외해야 함.',
+        );
+      },
+    );
+
+    test('emulator-indicative fingerprint still matches "emulator" keyword',
+        () {
+      final out = build(
+        manufacturer: 'unknown',
+        model: 'Android SDK built for x86_64',
+        brand: 'generic',
+        fingerprint:
+            'generic/sdk_gphone64_x86_64/emulator:13/TE1A.220922.034/9692585:userdebug/test-keys',
+        product: 'sdk_gphone64_x86_64',
+        device: 'emulator',
+        hardware: 'ranchu',
+        tags: 'test-keys',
+        type: 'userdebug',
+      );
+      expect(VirtualMachineDetector.containsWholeToken(out, 'emulator'), isTrue);
+      expect(VirtualMachineDetector.containsWholeToken(out, 'ranchu'), isTrue);
+      expect(VirtualMachineDetector.containsWholeToken(out, 'test-keys'),
+          isTrue);
+    });
+  });
+
   group('WebPSupportInfo', () {
     test('기본값은 모두 false', () {
       const info = WebPSupportInfo();


### PR DESCRIPTION
## Summary

- `VirtualMachineDetector._getBuildCheckResults` 의 deviceInfo 합성에서 `info.systemFeatures.join(' ')` 제거
- 합성 로직을 `buildDeviceInfoForMatching` static helper (`@visibleForTesting`) 로 분리
- 회귀 테스트 6 case 추가 — Galaxy A12 인풋에서 `cloud` 가 매치되지 않음, 동시에 emulator 인풋에서는 `ranchu`/`emulator`/`test-keys` 매치 보장

## Root cause

`containsWholeToken` 의 regex `(?<![A-Za-z0-9_])kw(?![A-Za-z0-9_])` 는 `.` 을 단어 경계로 취급함 (이건 `com.emulator.test` 같은 패키지명 기반 매칭을 위해 의도된 설계). 그러나 deviceInfo 에 `info.systemFeatures.join(' ')` 까지 합쳐버리면 Samsung 단말의 정상 시스템 앱 `com.samsung.android.cloud` 같은 패키지가 generic 키워드 `cloud` 에 whole-token 매치돼서 ban 이 발생함.

## 영향

**2025-02-03 ~ 2025-02-14 (11일)** 동안 `VIRTUAL_KEYWORDS='cloud'` 가 켜져있던 윈도우에서:
- 595건 ban → **594건 (99.8%) 이 정상 보급형 단말 FP** (Samsung/Infinix/Itel/LG)
- 119명 distinct user, 1인당 평균 5번 재밴 cascade
- 최근 30일 활동 88건, 90일 207건 — ban 이후에도 계속 앱을 켜려고 시도한 실유저

운영 측 조치 (이미 적용 완료, 별도 작업):
- `config.VIRTUAL_KEYWORDS = ''` 로 비움
- 594건 unban (`device_bans.unbanned_at` 채움, `devices.is_banned=false`)
- iOS Simulator TP 1건은 잔존

## 코드 변경 의도

이 PR 은 **회귀 차단**이 목적. config 가 다시 generic 키워드를 받게 되더라도 systemFeatures 패키지명이 더 이상 노이즈 소스가 되지 않도록 하는 근본 fix.

패키지명 기반 매칭이 추후 필요해지면 별도 keyword config (`VIRTUAL_PACKAGE_KEYWORDS` 같은) + exact match 로 분리할 것 (이번 PR 범위 밖).

## Test plan

- [x] `flutter test test/core/utils/virtual_machine_detector_test.dart test/core/utils/virtual_machine_detector_coverage_test.dart test/core/utils/vm_detector_units_test.dart test/core/utils/vm_detection_models_test.dart` → 159건 전부 통과
- [x] `flutter analyze lib/core/utils/virtual_machine_detector.dart test/core/utils/virtual_machine_detector_test.dart` → No issues found
- [x] 신규 회귀 테스트 — Galaxy A12 인풋 + `cloud` 키워드 → not matched
- [x] 신규 가드 — emulator 인풋 (`ranchu`, `emulator`, `test-keys`) → 여전히 매치

🤖 Generated with [Claude Code](https://claude.com/claude-code)