### PR TITLE
feat(device-fingerprint): Android OS-build hash → UUID v4 (collision fix)

### DIFF
--- a/picnic_lib/lib/core/utils/device_fingerprint.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint.dart
@@ -2,30 +2,45 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:picnic_lib/core/utils/device_fingerprint_helper.dart';
 import 'package:universal_platform/universal_platform.dart';
+import 'package:uuid/uuid.dart';
 
 class DeviceFingerprint {
   static const _storage = FlutterSecureStorage();
   static const _fingerprintKey = 'device_fingerprint';
+  static const _uuidVersionKey = 'device_fingerprint_v2_uuid';
   static final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
+  static const _uuidGen = Uuid();
 
-  /// 기기 식별자 가져오기
+  /// 기기 식별자 가져오기.
+  ///
+  /// v2 정책: Android 의 OS-level build fingerprint 가 같은 모델+펌웨어
+  /// 사용자 사이에 collision 을 일으켜 anti-abuse device cohort 가 FP 를
+  /// 다발 → flutter_secure_storage 에 영구 저장된 UUID v4 로 전환.
+  /// iOS 는 identifierForVendor 가 이미 vendor-unique 라 안전하지만,
+  /// 일관성 + 단일 path 위해 platform 무관 UUID 사용.
+  ///
+  /// 점진 마이그레이션:
+  ///   1. v2 키 (device_fingerprint_v2_uuid) 우선
+  ///   2. legacy 키 (device_fingerprint) — 옛 설치본만 fallback
+  ///   3. 신규 설치 / 둘 다 없으면 UUID v4 생성
   static Future<String> getDeviceId() async {
-    // 1. 저장된 지문이 있는지 확인
-    String? storedFingerprint = await _storage.read(key: _fingerprintKey);
-    if (storedFingerprint != null) {
-      return storedFingerprint;
+    final uuid = await _storage.read(key: _uuidVersionKey);
+    if (uuid != null && uuid.isNotEmpty) {
+      return uuid;
     }
 
-    // 2. 새로운 지문 생성
-    String fingerprint = await _generateFingerprint();
+    final legacy = await _storage.read(key: _fingerprintKey);
+    if (legacy != null && legacy.isNotEmpty) {
+      return legacy;
+    }
 
-    // 3. 생성된 지문 저장
-    await _storage.write(key: _fingerprintKey, value: fingerprint);
-
-    return fingerprint;
+    final fresh = _uuidGen.v4();
+    await _storage.write(key: _uuidVersionKey, value: fresh);
+    return fresh;
   }
 
-  /// 기기 지문 생성
+  /// 기기 지문 생성 (legacy path, v2 마이그레이션 이후 호출 안 됨).
+  /// reset()/verify() 호환을 위해 유지.
   static Future<String> _generateFingerprint() async {
     Map<String, dynamic> deviceData = {};
 
@@ -60,9 +75,10 @@ class DeviceFingerprint {
     return DeviceFingerprintHelper.generateHash(deviceData);
   }
 
-  /// 기기 지문 초기화
+  /// 기기 지문 초기화 — legacy 와 v2 키 모두 제거.
   static Future<void> reset() async {
     await _storage.delete(key: _fingerprintKey);
+    await _storage.delete(key: _uuidVersionKey);
   }
 
   /// 기기 지문 검증

--- a/picnic_lib/test/core/utils/device_fingerprint_test.dart
+++ b/picnic_lib/test/core/utils/device_fingerprint_test.dart
@@ -2,126 +2,108 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:picnic_lib/core/utils/device_fingerprint.dart';
 
+const _uuidRegex = r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$';
+
 void main() {
   group('DeviceFingerprint', () {
     setUp(() {
       FlutterSecureStorage.setMockInitialValues({});
     });
 
-    group('getDeviceId', () {
-      test('generates a new fingerprint when none is stored', () async {
+    group('getDeviceId — v2 (UUID)', () {
+      test('신규 설치 시 UUID v4 생성', () async {
         final deviceId = await DeviceFingerprint.getDeviceId();
         expect(deviceId, isNotNull);
         expect(deviceId, isNotEmpty);
-        // SHA-256 hash is 64 hex chars
-        expect(deviceId.length, 64);
+        expect(deviceId, matches(RegExp(_uuidRegex)));
       });
 
-      test('returns the same fingerprint on subsequent calls', () async {
+      test('재호출 시 동일 UUID 반환 (persistence)', () async {
         final first = await DeviceFingerprint.getDeviceId();
         final second = await DeviceFingerprint.getDeviceId();
         expect(first, equals(second));
       });
 
-      test('returns stored fingerprint if available', () async {
-        const storedFingerprint = 'abc123stored';
+      test('v2 키 저장 확인', () async {
+        await DeviceFingerprint.getDeviceId();
+        const storage = FlutterSecureStorage();
+        final stored = await storage.read(key: 'device_fingerprint_v2_uuid');
+        expect(stored, isNotNull);
+        expect(stored, matches(RegExp(_uuidRegex)));
+      });
+    });
+
+    group('getDeviceId — v1 legacy fallback', () {
+      test('legacy 키만 있으면 그 값 반환 (점진 마이그레이션)', () async {
+        const legacyHash =
+            'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
         FlutterSecureStorage.setMockInitialValues({
-          'device_fingerprint': storedFingerprint,
+          'device_fingerprint': legacyHash,
         });
 
         final deviceId = await DeviceFingerprint.getDeviceId();
-        expect(deviceId, equals(storedFingerprint));
+        expect(deviceId, equals(legacyHash));
       });
 
-      test('fingerprint is a valid hex string', () async {
+      test('v2 + legacy 둘 다 있으면 v2 우선', () async {
+        FlutterSecureStorage.setMockInitialValues({
+          'device_fingerprint': 'legacy_value',
+          'device_fingerprint_v2_uuid': '11111111-2222-4333-a444-555555555555',
+        });
+
         final deviceId = await DeviceFingerprint.getDeviceId();
-        // SHA-256 produces only hex characters
-        expect(deviceId, matches(RegExp(r'^[a-f0-9]+$')));
+        expect(deviceId, equals('11111111-2222-4333-a444-555555555555'));
       });
     });
 
     group('reset', () {
-      test('clears the stored fingerprint', () async {
-        // Generate and store a fingerprint
-        await DeviceFingerprint.getDeviceId();
+      test('v2 와 legacy 키 둘 다 제거', () async {
+        FlutterSecureStorage.setMockInitialValues({
+          'device_fingerprint': 'legacy_value',
+          'device_fingerprint_v2_uuid': '11111111-2222-4333-a444-555555555555',
+        });
+        const storage = FlutterSecureStorage();
 
-        // Reset it
         await DeviceFingerprint.reset();
 
-        // After reset, a new fingerprint should be generated
-        // (it will be different storage key lookup, but since we're in test
-        // the mock storage is cleared)
-        // Just verify reset completes without error
+        expect(await storage.read(key: 'device_fingerprint'), isNull);
+        expect(await storage.read(key: 'device_fingerprint_v2_uuid'), isNull);
       });
 
-      test('completes without error even when no fingerprint stored', () async {
+      test('저장된 값 없을 때 reset 도 정상 완료', () async {
         await DeviceFingerprint.reset();
-        // Should not throw
       });
     });
 
     group('verify', () {
-      test('returns true for matching fingerprint', () async {
+      test('현재 deviceId 와 같으면 true', () async {
         final deviceId = await DeviceFingerprint.getDeviceId();
         final isValid = await DeviceFingerprint.verify(deviceId);
         expect(isValid, isTrue);
       });
 
-      test('returns false for non-matching fingerprint', () async {
+      test('다른 값이면 false', () async {
         await DeviceFingerprint.getDeviceId();
-        final isValid = await DeviceFingerprint.verify('wrong_fingerprint');
+        final isValid = await DeviceFingerprint.verify('wrong_value');
         expect(isValid, isFalse);
       });
 
-      test('returns false for empty string', () async {
+      test('빈 문자열이면 false', () async {
         await DeviceFingerprint.getDeviceId();
         final isValid = await DeviceFingerprint.verify('');
         expect(isValid, isFalse);
       });
     });
 
-    group('stored fingerprint persistence', () {
-      test('stores fingerprint after first generation', () async {
-        final storage = const FlutterSecureStorage();
-
-        // Initially no fingerprint
-        final before = await storage.read(key: 'device_fingerprint');
-        expect(before, isNull);
-
-        // Generate fingerprint
-        final deviceId = await DeviceFingerprint.getDeviceId();
-
-        // Now it should be stored
-        final after = await storage.read(key: 'device_fingerprint');
-        expect(after, equals(deviceId));
-      });
-
-      test('reset removes the stored fingerprint', () async {
-        final storage = const FlutterSecureStorage();
-
-        // Generate fingerprint
-        await DeviceFingerprint.getDeviceId();
-        final before = await storage.read(key: 'device_fingerprint');
-        expect(before, isNotNull);
-
-        // Reset
-        await DeviceFingerprint.reset();
-        final after = await storage.read(key: 'device_fingerprint');
-        expect(after, isNull);
-      });
-    });
-
-    group('verify after reset', () {
-      test('old fingerprint no longer verifies after reset', () async {
+    group('reset → getDeviceId 재생성', () {
+      test('reset 후 새 UUID 발급', () async {
         final oldId = await DeviceFingerprint.getDeviceId();
-        expect(await DeviceFingerprint.verify(oldId), isTrue);
-
         await DeviceFingerprint.reset();
 
-        // After reset, getDeviceId generates a new fingerprint
         final newId = await DeviceFingerprint.getDeviceId();
-        // The new fingerprint should verify
-        expect(await DeviceFingerprint.verify(newId), isTrue);
+        expect(newId, isNotEmpty);
+        expect(newId, matches(RegExp(_uuidRegex)));
+        expect(newId, isNot(equals(oldId)));
       });
     });
   });


### PR DESCRIPTION
## Summary
\`device_fingerprint.dart\` 의 Android path 가 OS-level build 데이터(brand/model/manufacturer/display/build fingerprint 등) 만 hash → **같은 모델+펌웨어 사용자가 동일 device_hash 생성** → anti-abuse device cohort 가 false-positive 다발.

이유림1559 사례 (decision 8456 / 8860) — KR Galaxy 모델 + 펌웨어 동일 unrelated user 5명이 같은 hash 받아 \`attendance_device_5_accounts\` 차단. 본인은 단일 계정 주장 (사실 확인됨).

## Changes
- \`getDeviceId()\` — 새 키 \`device_fingerprint_v2_uuid\` 우선, 옛 키 \`device_fingerprint\` 는 legacy fallback (점진 마이그레이션).
- iOS 도 platform 무관 UUID v4 (single path, identifierForVendor 의존 제거).
- \`_generateFingerprint()\` — legacy compat 유지하되 호출 path 제거.
- \`reset()\` — 두 키 모두 제거.
- 테스트 11/11 통과 (UUID v4 패턴 + legacy fallback 분기 신규 추가).

## Migration strategy
- 기존 설치본: 옛 hash 그대로 유지 → 차단 회피 0
- 신규 설치 / fresh storage: UUID v4 받음
- 1-2주 후 새 install 비중 증가로 cohort collision FP 자연 감소

## Companion DB change (별도 적용 완료)
\`anti_abuse_policies.device_block_threshold\` 임시 완화: 5→8 / suspect 3→5. 마이그레이션 기간 collision FP 분산. fingerprint 정상화 후 5/3 재강화 검토.

## Test plan
- [x] flutter test 11/11
- [ ] Codemagic store release 트리거 (\`picnic-v*\` 태그)
- [ ] 새 install 의 device_hash 가 UUID 패턴 확인 (request_ip_log 샘플링)
- [ ] device cohort FP 추이 모니터링 (1-2주)

🤖 Generated with [Claude Code](https://claude.com/claude-code)