### PR TITLE
feat(device-fingerprint): legacy hash 강제 마이그레이션 (즉시 UUID 전환)

### DIFF
--- a/picnic_lib/lib/core/utils/device_fingerprint.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint.dart
@@ -19,10 +19,13 @@ class DeviceFingerprint {
   /// iOS 는 identifierForVendor 가 이미 vendor-unique 라 안전하지만,
   /// 일관성 + 단일 path 위해 platform 무관 UUID 사용.
   ///
-  /// 점진 마이그레이션:
+  /// 강제 마이그레이션 (v2):
   ///   1. v2 키 (device_fingerprint_v2_uuid) 우선
-  ///   2. legacy 키 (device_fingerprint) — 옛 설치본만 fallback
-  ///   3. 신규 설치 / 둘 다 없으면 UUID v4 생성
+  ///   2. legacy 키 (device_fingerprint) 가 있으면 무조건 새 UUID 발급 + 옛 키 제거.
+  ///      build-based hash collision 즉시 해소.
+  ///      trade-off: 차단된 farm user 도 새 UUID 받아 cohort 1회 흩어짐 (attendance 매일 1회라
+  ///      다시 cohort 형성에 1-2일, farm candy 누적 미미).
+  ///   3. 둘 다 없으면 신규 UUID v4 생성.
   static Future<String> getDeviceId() async {
     final uuid = await _storage.read(key: _uuidVersionKey);
     if (uuid != null && uuid.isNotEmpty) {
@@ -31,7 +34,11 @@ class DeviceFingerprint {
 
     final legacy = await _storage.read(key: _fingerprintKey);
     if (legacy != null && legacy.isNotEmpty) {
-      return legacy;
+      // 강제 마이그레이션 — legacy hash 폐기, 신규 UUID.
+      final migrated = _uuidGen.v4();
+      await _storage.write(key: _uuidVersionKey, value: migrated);
+      await _storage.delete(key: _fingerprintKey);
+      return migrated;
     }
 
     final fresh = _uuidGen.v4();

--- a/picnic_lib/test/core/utils/device_fingerprint_test.dart
+++ b/picnic_lib/test/core/utils/device_fingerprint_test.dart
@@ -33,8 +33,8 @@ void main() {
       });
     });
 
-    group('getDeviceId — v1 legacy fallback', () {
-      test('legacy 키만 있으면 그 값 반환 (점진 마이그레이션)', () async {
+    group('getDeviceId — v1 legacy 강제 마이그레이션', () {
+      test('legacy 키만 있으면 새 UUID 발급 + legacy 제거', () async {
         const legacyHash =
             'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
         FlutterSecureStorage.setMockInitialValues({
@@ -42,10 +42,32 @@ void main() {
         });
 
         final deviceId = await DeviceFingerprint.getDeviceId();
-        expect(deviceId, equals(legacyHash));
+        // legacy hash 가 아닌 새 UUID 가 반환되어야 함 (강제 마이그레이션)
+        expect(deviceId, isNot(equals(legacyHash)));
+        expect(deviceId, matches(RegExp(_uuidRegex)));
+
+        // legacy 키는 제거됐어야 함
+        const storage = FlutterSecureStorage();
+        final legacyAfter = await storage.read(key: 'device_fingerprint');
+        expect(legacyAfter, isNull);
+
+        // v2 키에 새 UUID 저장됐어야 함
+        final v2After = await storage.read(key: 'device_fingerprint_v2_uuid');
+        expect(v2After, equals(deviceId));
       });
 
-      test('v2 + legacy 둘 다 있으면 v2 우선', () async {
+      test('재호출 시 마이그레이션된 UUID 안정적 반환', () async {
+        FlutterSecureStorage.setMockInitialValues({
+          'device_fingerprint': 'old_legacy_hash',
+        });
+
+        final first = await DeviceFingerprint.getDeviceId();
+        final second = await DeviceFingerprint.getDeviceId();
+        expect(first, equals(second));
+        expect(first, matches(RegExp(_uuidRegex)));
+      });
+
+      test('v2 + legacy 둘 다 있으면 v2 우선 (legacy 폐기 안 함)', () async {
         FlutterSecureStorage.setMockInitialValues({
           'device_fingerprint': 'legacy_value',
           'device_fingerprint_v2_uuid': '11111111-2222-4333-a444-555555555555',


### PR DESCRIPTION
## Summary
PR #44 의 fallback 정책이 옛 build-based hash 를 그대로 유지하도록 설계 → 이미 설치된 99% 사용자 영향 0 → collision FP 즉시 해소 안 됨. 새 install / data clear 만 UUID 받음, iOS Keychain 정책상 더 느림.

## Change
\`getDeviceId()\` 의 legacy fallback 분기를 **강제 마이그레이션** 으로:
- legacy 키 발견 → **새 UUID 발급 + legacy 키 제거**
- v2 키 우선은 동일

## Trade-off (의도된 위험)
- 차단된 farm user 도 새 UUID 받음 → cohort 1회 흩어짐 → 1회 회피 가능
- attendance 매일 1회 정책상 다시 cohort 형성에 1-2일 → farm candy 누적 미미
- 새 cohort 형성 시 device 신호로 재차단 (block_threshold 8 적용 중)

## Test plan
- [x] flutter test 12/12 (legacy 강제 마이그레이션 분기 + UUID 안정성 테스트 신규)
- [ ] Shorebird OTA patch 재배포 (양 platform)
- [ ] 다음 차단 alert 의 device_hash 가 UUID v4 패턴인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)