### PR TITLE
fix(device-ban): isBannedFromResult 가 unbanned_at IS NULL 일 때만 ban 판단

### DIFF
--- a/picnic_lib/lib/core/services/device_manager_helper.dart
+++ b/picnic_lib/lib/core/services/device_manager_helper.dart
@@ -114,10 +114,13 @@ class DeviceManagerHelper {
 
   /// Interpret whether a device is banned from a query result.
   ///
-  /// Returns `true` if the result is not null (i.e. a matching row was found).
+  /// Returns `true` only when a matching row exists AND `unbanned_at` is null.
+  /// device_bans 의 unban 처리는 row 삭제 대신 `unbanned_at` 컬럼 채움(soft unban).
+  /// 옛 로직은 row 존재만으로 ban 판단해 운영자의 unban 작업이 무효였음.
   @visibleForTesting
   static bool isBannedFromResult(Map<String, dynamic>? result) {
-    return result != null;
+    if (result == null) return false;
+    return result['unbanned_at'] == null;
   }
 
   /// Build the update payload for marking a device as last seen now.

--- a/picnic_lib/test/core/services/device_manager_helper_test.dart
+++ b/picnic_lib/test/core/services/device_manager_helper_test.dart
@@ -288,20 +288,33 @@ void main() {
   });
 
   group('DeviceManagerHelper.isBannedFromResult', () {
-    test('returns true when result is not null', () {
-      final result = DeviceManagerHelper.isBannedFromResult(
-        {'device_id': 'abc', 'reason': 'abuse'},
-      );
-      expect(result, isTrue);
-    });
-
-    test('returns false when result is null', () {
+    test('null 결과 → ban 아님', () {
       final result = DeviceManagerHelper.isBannedFromResult(null);
       expect(result, isFalse);
     });
 
-    test('returns true for empty map (row exists but no data)', () {
-      final result = DeviceManagerHelper.isBannedFromResult({});
+    test('unbanned_at 가 null 인 active ban row → ban 임', () {
+      final result = DeviceManagerHelper.isBannedFromResult(
+        {'device_id': 'abc', 'reason': 'abuse', 'unbanned_at': null},
+      );
+      expect(result, isTrue);
+    });
+
+    test('unbanned_at 가 채워진 row (soft unban) → ban 아님 — soft unban 인식', () {
+      final result = DeviceManagerHelper.isBannedFromResult({
+        'device_id': 'abc',
+        'reason': 'abuse',
+        'unbanned_at': '2026-05-26T09:03:57.857821+00:00',
+      });
+      expect(result, isFalse);
+    });
+
+    test('unbanned_at 키 없는 empty / 옛 row → ban 으로 처리 (보수적)', () {
+      // 기본 schema 에서는 항상 unbanned_at 컬럼 존재. 누락은 예상치 못한 케이스.
+      // null/missing 동등 처리: row 가 있으면 ban (보수적).
+      final result = DeviceManagerHelper.isBannedFromResult({
+        'device_id': 'abc',
+      });
       expect(result, isTrue);
     });
   });


### PR DESCRIPTION
## Summary
\`device_bans\` 의 unban 은 row 삭제가 아닌 \`unbanned_at\` 컬럼 채움(soft unban) 방식인데, 옛 \`isBannedFromResult\` 가 **row 존재만으로 ban 판단** → 운영자가 unban 처리해도 클라이언트는 ban_screen 표시. **5/26 VM detector FP 594건 unban 작업 사실상 무효** 였음.

## Diagnosis
사용자 device \`22a87cf9…\` 가 5/26 09:03 KST 에 unban 처리됐는데 5/27 13:55 KST 에 여전히 ban_screen 노출. \`device_manager_helper.dart:119-121\`:

\`\`\`dart
static bool isBannedFromResult(Map<String, dynamic>? result) {
  return result != null;  // ❌ unbanned_at 무시
}
\`\`\`

## Change
\`\`\`dart
static bool isBannedFromResult(Map<String, dynamic>? result) {
  if (result == null) return false;
  return result['unbanned_at'] == null;
}
\`\`\`

## DB hot fix (동시 적용)
\`DELETE FROM device_bans WHERE unbanned_at IS NOT NULL\` — 594 rows hard delete. 클라이언트 코드 무관 즉시 효과.

## Test plan
- [x] flutter test 34/34 (soft unban 인식 / null active ban / row 없음 / 보수적 fallback)
- [x] DB hard delete 적용 완료 (active 1건만 유지)
- [ ] Shorebird OTA patch (v3) — 다음 차단 시 클라이언트 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)