### PR TITLE
fix(popup): platform 필터 + stop_at NULL 허용

### DIFF
--- a/picnic_lib/lib/data/models/common/popup.dart
+++ b/picnic_lib/lib/data/models/common/popup.dart
@@ -10,6 +10,7 @@ abstract class Popup with _$Popup {
     required Map<String, String> title,
     required Map<String, String> content,
     Map<String, String>? image,
+    String? platform,
     @JsonKey(name: 'created_at') DateTime? createdAt,
     @JsonKey(name: 'updated_at') DateTime? updatedAt,
     @JsonKey(name: 'deleted_at') DateTime? deletedAt,

--- a/picnic_lib/lib/data/repositories/popup_repository.dart
+++ b/picnic_lib/lib/data/repositories/popup_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:picnic_lib/core/utils/logger.dart';
 import 'package:picnic_lib/data/models/common/popup.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -7,20 +8,33 @@ class PopupRepository {
 
   Future<List<Popup>> fetchPopups() async {
     try {
+      final now = DateTime.now().toIso8601String();
       final response = await _client
           .from('popup')
           .select()
-          .lte('start_at', DateTime.now().toIso8601String())
-          .gte('stop_at', DateTime.now().toIso8601String())
+          .lte('start_at', now)
+          .or('stop_at.is.null,stop_at.gte.$now')
           .filter('deleted_at', 'is', null)
           .order('start_at', ascending: true);
 
-      return (response as List)
+      final popups = (response as List)
           .map((e) => Popup.fromJson(e as Map<String, dynamic>))
           .toList();
+
+      return popups.where(_isForCurrentPlatform).toList();
     } catch (e, s) {
       logger.e('Error fetching popups', error: e, stackTrace: s);
       return [];
     }
+  }
+
+  bool _isForCurrentPlatform(Popup popup) {
+    final platform = popup.platform;
+    if (platform == null || platform.isEmpty || platform == 'all') {
+      return true;
+    }
+    if (Platform.isAndroid) return platform == 'android';
+    if (Platform.isIOS) return platform == 'ios';
+    return false;
   }
 }

--- a/picnic_lib/lib/generated/providers/models/common/popup.freezed.dart
+++ b/picnic_lib/lib/generated/providers/models/common/popup.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Popup {
 
- int get id; Map<String, String> get title; Map<String, String> get content; Map<String, String>? get image;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'updated_at') DateTime? get updatedAt;@JsonKey(name: 'deleted_at') DateTime? get deletedAt;@JsonKey(name: 'start_at') DateTime? get startAt;@JsonKey(name: 'stop_at') DateTime? get stopAt;
+ int get id; Map<String, String> get title; Map<String, String> get content; Map<String, String>? get image; String? get platform;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'updated_at') DateTime? get updatedAt;@JsonKey(name: 'deleted_at') DateTime? get deletedAt;@JsonKey(name: 'start_at') DateTime? get startAt;@JsonKey(name: 'stop_at') DateTime? get stopAt;
 /// Create a copy of Popup
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $PopupCopyWith<Popup> get copyWith => _$PopupCopyWithImpl<Popup>(this as Popup, 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Popup&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.title, title)&&const DeepCollectionEquality().equals(other.content, content)&&const DeepCollectionEquality().equals(other.image, image)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Popup&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.title, title)&&const DeepCollectionEquality().equals(other.content, content)&&const DeepCollectionEquality().equals(other.image, image)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(title),const DeepCollectionEquality().hash(content),const DeepCollectionEquality().hash(image),createdAt,updatedAt,deletedAt,startAt,stopAt);
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(title),const DeepCollectionEquality().hash(content),const DeepCollectionEquality().hash(image),platform,createdAt,updatedAt,deletedAt,startAt,stopAt);
 
 @override
 String toString() {
-  return 'Popup(id: $id, title: $title, content: $content, image: $image, createdAt: $createdAt, updatedAt: $updatedAt, deletedAt: $deletedAt, startAt: $startAt, stopAt: $stopAt)';
+  return 'Popup(id: $id, title: $title, content: $content, image: $image, platform: $platform, createdAt: $createdAt, updatedAt: $updatedAt, deletedAt: $deletedAt, startAt: $startAt, stopAt: $stopAt)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $PopupCopyWith<$Res>  {
   factory $PopupCopyWith(Popup value, $Res Function(Popup) _then) = _$PopupCopyWithImpl;
 @useResult
 $Res call({
- int id, Map<String, String> title, Map<String, String> content, Map<String, String>? image,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt,@JsonKey(name: 'deleted_at') DateTime? deletedAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'stop_at') DateTime? stopAt
+ int id, Map<String, String> title, Map<String, String> content, Map<String, String>? image, String? platform,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt,@JsonKey(name: 'deleted_at') DateTime? deletedAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'stop_at') DateTime? stopAt
 });
 
 
@@ -65,13 +65,14 @@ class _$PopupCopyWithImpl<$Res>
 
 /// Create a copy of Popup
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? content = null,Object? image = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? deletedAt = freezed,Object? startAt = freezed,Object? stopAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? content = null,Object? image = freezed,Object? platform = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? deletedAt = freezed,Object? startAt = freezed,Object? stopAt = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as Map<String, String>,content: null == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
 as Map<String, String>,image: freezed == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
-as Map<String, String>?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,platform: freezed == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,startAt: freezed == startAt ? _self.startAt : startAt // ignore: cast_nullable_to_non_nullable
@@ -161,10 +162,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  Map<String, String> title,  Map<String, String> content,  Map<String, String>? image, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt, @JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'stop_at')  DateTime? stopAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  Map<String, String> title,  Map<String, String> content,  Map<String, String>? image,  String? platform, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt, @JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'stop_at')  DateTime? stopAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Popup() when $default != null:
-return $default(_that.id,_that.title,_that.content,_that.image,_that.createdAt,_that.updatedAt,_that.deletedAt,_that.startAt,_that.stopAt);case _:
+return $default(_that.id,_that.title,_that.content,_that.image,_that.platform,_that.createdAt,_that.updatedAt,_that.deletedAt,_that.startAt,_that.stopAt);case _:
   return orElse();
 
 }
@@ -182,10 +183,10 @@ return $default(_that.id,_that.title,_that.content,_that.image,_that.createdAt,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  Map<String, String> title,  Map<String, String> content,  Map<String, String>? image, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt, @JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'stop_at')  DateTime? stopAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  Map<String, String> title,  Map<String, String> content,  Map<String, String>? image,  String? platform, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt, @JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'stop_at')  DateTime? stopAt)  $default,) {final _that = this;
 switch (_that) {
 case _Popup():
-return $default(_that.id,_that.title,_that.content,_that.image,_that.createdAt,_that.updatedAt,_that.deletedAt,_that.startAt,_that.stopAt);case _:
+return $default(_that.id,_that.title,_that.content,_that.image,_that.platform,_that.createdAt,_that.updatedAt,_that.deletedAt,_that.startAt,_that.stopAt);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -202,10 +203,10 @@ return $default(_that.id,_that.title,_that.content,_that.image,_that.createdAt,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  Map<String, String> title,  Map<String, String> content,  Map<String, String>? image, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt, @JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'stop_at')  DateTime? stopAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  Map<String, String> title,  Map<String, String> content,  Map<String, String>? image,  String? platform, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt, @JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'stop_at')  DateTime? stopAt)?  $default,) {final _that = this;
 switch (_that) {
 case _Popup() when $default != null:
-return $default(_that.id,_that.title,_that.content,_that.image,_that.createdAt,_that.updatedAt,_that.deletedAt,_that.startAt,_that.stopAt);case _:
+return $default(_that.id,_that.title,_that.content,_that.image,_that.platform,_that.createdAt,_that.updatedAt,_that.deletedAt,_that.startAt,_that.stopAt);case _:
   return null;
 
 }
@@ -217,7 +218,7 @@ return $default(_that.id,_that.title,_that.content,_that.image,_that.createdAt,_
 @JsonSerializable()
 
 class _Popup implements Popup {
-  const _Popup({required this.id, required final  Map<String, String> title, required final  Map<String, String> content, final  Map<String, String>? image, @JsonKey(name: 'created_at') this.createdAt, @JsonKey(name: 'updated_at') this.updatedAt, @JsonKey(name: 'deleted_at') this.deletedAt, @JsonKey(name: 'start_at') this.startAt, @JsonKey(name: 'stop_at') this.stopAt}): _title = title,_content = content,_image = image;
+  const _Popup({required this.id, required final  Map<String, String> title, required final  Map<String, String> content, final  Map<String, String>? image, this.platform, @JsonKey(name: 'created_at') this.createdAt, @JsonKey(name: 'updated_at') this.updatedAt, @JsonKey(name: 'deleted_at') this.deletedAt, @JsonKey(name: 'start_at') this.startAt, @JsonKey(name: 'stop_at') this.stopAt}): _title = title,_content = content,_image = image;
   factory _Popup.fromJson(Map<String, dynamic> json) => _$PopupFromJson(json);
 
 @override final  int id;
@@ -244,6 +245,7 @@ class _Popup implements Popup {
   return EqualUnmodifiableMapView(value);
 }
 
+@override final  String? platform;
 @override@JsonKey(name: 'created_at') final  DateTime? createdAt;
 @override@JsonKey(name: 'updated_at') final  DateTime? updatedAt;
 @override@JsonKey(name: 'deleted_at') final  DateTime? deletedAt;
@@ -263,16 +265,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Popup&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._title, _title)&&const DeepCollectionEquality().equals(other._content, _content)&&const DeepCollectionEquality().equals(other._image, _image)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Popup&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._title, _title)&&const DeepCollectionEquality().equals(other._content, _content)&&const DeepCollectionEquality().equals(other._image, _image)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_title),const DeepCollectionEquality().hash(_content),const DeepCollectionEquality().hash(_image),createdAt,updatedAt,deletedAt,startAt,stopAt);
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_title),const DeepCollectionEquality().hash(_content),const DeepCollectionEquality().hash(_image),platform,createdAt,updatedAt,deletedAt,startAt,stopAt);
 
 @override
 String toString() {
-  return 'Popup(id: $id, title: $title, content: $content, image: $image, createdAt: $createdAt, updatedAt: $updatedAt, deletedAt: $deletedAt, startAt: $startAt, stopAt: $stopAt)';
+  return 'Popup(id: $id, title: $title, content: $content, image: $image, platform: $platform, createdAt: $createdAt, updatedAt: $updatedAt, deletedAt: $deletedAt, startAt: $startAt, stopAt: $stopAt)';
 }
 
 
@@ -283,7 +285,7 @@ abstract mixin class _$PopupCopyWith<$Res> implements $PopupCopyWith<$Res> {
   factory _$PopupCopyWith(_Popup value, $Res Function(_Popup) _then) = __$PopupCopyWithImpl;
 @override @useResult
 $Res call({
- int id, Map<String, String> title, Map<String, String> content, Map<String, String>? image,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt,@JsonKey(name: 'deleted_at') DateTime? deletedAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'stop_at') DateTime? stopAt
+ int id, Map<String, String> title, Map<String, String> content, Map<String, String>? image, String? platform,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt,@JsonKey(name: 'deleted_at') DateTime? deletedAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'stop_at') DateTime? stopAt
 });
 
 
@@ -300,13 +302,14 @@ class __$PopupCopyWithImpl<$Res>
 
 /// Create a copy of Popup
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? content = null,Object? image = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? deletedAt = freezed,Object? startAt = freezed,Object? stopAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? content = null,Object? image = freezed,Object? platform = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? deletedAt = freezed,Object? startAt = freezed,Object? stopAt = freezed,}) {
   return _then(_Popup(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self._title : title // ignore: cast_nullable_to_non_nullable
 as Map<String, String>,content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
 as Map<String, String>,image: freezed == image ? _self._image : image // ignore: cast_nullable_to_non_nullable
-as Map<String, String>?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,platform: freezed == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,startAt: freezed == startAt ? _self.startAt : startAt // ignore: cast_nullable_to_non_nullable

--- a/picnic_lib/lib/generated/providers/models/common/popup.g.dart
+++ b/picnic_lib/lib/generated/providers/models/common/popup.g.dart
@@ -26,6 +26,7 @@ _Popup _$PopupFromJson(Map<String, dynamic> json) => $checkedCreate(
           (k, e) => MapEntry(k, e as String),
         ),
       ),
+      platform: $checkedConvert('platform', (v) => v as String?),
       createdAt: $checkedConvert(
         'created_at',
         (v) => v == null ? null : DateTime.parse(v as String),
@@ -63,6 +64,7 @@ Map<String, dynamic> _$PopupToJson(_Popup instance) => <String, dynamic>{
   'title': instance.title,
   'content': instance.content,
   'image': instance.image,
+  'platform': instance.platform,
   'created_at': instance.createdAt?.toIso8601String(),
   'updated_at': instance.updatedAt?.toIso8601String(),
   'deleted_at': instance.deletedAt?.toIso8601String(),


### PR DESCRIPTION
## Summary
picnic-web 의 popup 노출 이슈 (#36~#38) 를 점검하며 발견한 picnic-app 의 동일 영역 버그를 같이 수정.

## Root cause
1. \`PopupRepository.fetchPopups\` 가 \`platform\` 컬럼을 **전혀 필터하지 않음** → admin 이 \`platform='web'\` 으로 등록한 팝업 (예: popup id=5) 이 모바일 앱에도 노출됨.
2. \`Popup\` freezed 모델에 \`platform\` 필드가 없어 client 단 필터링도 불가.
3. \`gte('stop_at', now)\` 만 사용 → \`stop_at IS NULL\` 인 팝업은 앱에서만 안 뜸 (web 은 \`or(stop_at.is.null,stop_at.gte.now())\`).

## Changes
- \`Popup\` 모델에 \`String? platform\` 필드 추가
- \`PopupRepository\`:
  - \`stop_at\`: \`gte\` → \`or('stop_at.is.null,stop_at.gte.<now>')\` (web 과 매칭)
  - 응답 데이터에 plataform 클라이언트 필터 (\`all\` / \`android\` / \`ios\`, null/empty 는 all 취급)
- freezed/json_serializable codegen 동시 커밋

## Test plan
- [ ] Android/iOS 빌드에서 popup id=5 (platform=web) 가 노출 안 되는지
- [ ] admin 에서 \`platform='all'\` 또는 \`platform='android'\`/\`'ios'\` 인 테스트 팝업이 정상 노출되는지
- [ ] \`stop_at\` NULL 팝업이 정상 노출되는지 (테스트 row 생성 후)

## Release plan
순수 Dart 변경이라 Shorebird patch 적용 가능. (메모리 \`picnic_app_shorebird_local_only\` 참조 — 로컬 CLI 만 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)