### PR TITLE
fix(search): 마이아티스트·후보요청에 뮤지컬 배우 노출

### DIFF
--- a/picnic_lib/lib/core/services/search_service.dart
+++ b/picnic_lib/lib/core/services/search_service.dart
@@ -6,6 +6,35 @@ import 'package:picnic_lib/data/models/vote/artist.dart';
 import 'package:picnic_lib/supabase_options.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+/// 아티스트 검색에서 어떤 카테고리(들)를 노출할지 결정하는 범위.
+///
+/// - [kpopOnly]: K-pop 아티스트만 (기존 기본 동작)
+/// - [musicalOnly]: 뮤지컬 배우만 (area == 'musical' 투표)
+/// - [kpopAndMusical]: K-pop + 뮤지컬 (마이아티스트 등 통합 노출)
+enum ArtistSearchScope { kpopOnly, musicalOnly, kpopAndMusical }
+
+/// 투표 `area` 값에 따른 아티스트 검색 범위.
+///
+/// 'musical' 투표는 뮤지컬 배우만, 그 외/null 은 기존 K-pop 으로 매핑한다.
+ArtistSearchScope artistSearchScopeForVoteArea(String? area) =>
+    area == 'musical'
+        ? ArtistSearchScope.musicalOnly
+        : ArtistSearchScope.kpopOnly;
+
+/// [scope] 에 해당하는 PostgREST `or=()` 필터 문자열을 만든다.
+///
+/// 단일 조건(`is_kpop.eq.true`)도 PostgREST `or` 로 표현되며 동작은 `.eq` 와 동일하다.
+String artistScopeOrFilter(ArtistSearchScope scope) {
+  switch (scope) {
+    case ArtistSearchScope.kpopOnly:
+      return 'is_kpop.eq.true';
+    case ArtistSearchScope.musicalOnly:
+      return 'is_musical.eq.true';
+    case ArtistSearchScope.kpopAndMusical:
+      return 'is_kpop.eq.true,is_musical.eq.true';
+  }
+}
+
 /// 공통 검색 서비스 클래스
 /// 다양한 엔티티 타입에 대한 검색 기능을 제공하는 재사용 가능한 모듈
 class SearchService {
@@ -330,11 +359,13 @@ class SearchService {
     int limit = 20,
     String language = 'ko',
     bool includeBookmarks = false,
+    ArtistSearchScope scope = ArtistSearchScope.kpopOnly,
   }) async {
     query = query.trim();
 
-    // 캐시 키 생성 (북마크 포함 여부도 키에 포함)
-    final cacheKey = 'artist_fast_${query}_${page}_${limit}_$includeBookmarks';
+    // 캐시 키 생성 (북마크 포함 여부 + 검색 범위도 키에 포함)
+    final cacheKey =
+        'artist_fast_${query}_${page}_${limit}_${includeBookmarks}_${scope.name}';
 
     // 캐시에서 조회 시도
     final cachedResult = _cache.get<List<ArtistModel>>(cacheKey);
@@ -381,7 +412,7 @@ class SearchService {
                 .from('artist')
                 .select(selectFields)
                 .neq('id', 0)
-                .eq('is_kpop', true)
+                .or(artistScopeOrFilter(scope)) // 검색 범위 (K-pop/뮤지컬)
                 .isFilter('deleted_at', null); // soft-deleted 아티스트 제외
 
             if (bookmarkedIds.isNotEmpty) {
@@ -426,7 +457,7 @@ class SearchService {
                 .from('artist')
                 .select(selectFields)
                 .neq('id', 0)
-                .eq('is_kpop', true)
+                .or(artistScopeOrFilter(scope)) // 검색 범위 (K-pop/뮤지컬)
                 .isFilter('deleted_at', null); // soft-deleted 아티스트 제외
 
             if (bookmarkedIds.isNotEmpty) {
@@ -446,7 +477,7 @@ class SearchService {
                 .from('artist')
                 .select(selectFields)
                 .neq('id', 0)
-                .eq('is_kpop', true)
+                .or(artistScopeOrFilter(scope)) // 검색 범위 (K-pop/뮤지컬)
                 .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
                 .order('name->>$language', ascending: true)
                 .range(page * limit, (page + 1) * limit - 1);
@@ -477,7 +508,7 @@ class SearchService {
             .from('artist')
             .select(selectFields)
             .neq('id', 0)
-            .eq('is_kpop', true)
+            .or(artistScopeOrFilter(scope)) // 검색 범위 (K-pop/뮤지컬)
             .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
             .order('name->>$language', ascending: true);
 
@@ -519,7 +550,7 @@ class SearchService {
           .from('artist')
           .select(selectFields)
           .neq('id', 0)
-          .eq('is_kpop', true)
+          .or(artistScopeOrFilter(scope)) // 검색 범위 (K-pop/뮤지컬)
           .isFilter('deleted_at', null) // soft-deleted 아티스트 제외
           .or('name->>ko.ilike.$searchPattern,name->>en.ilike.$searchPattern')
           .order('name->>$language', ascending: true)

--- a/picnic_lib/lib/data/models/vote/vote.dart
+++ b/picnic_lib/lib/data/models/vote/vote.dart
@@ -28,6 +28,7 @@ abstract class VoteModel with _$VoteModel {
           @JsonKey(name: 'is_upcoming') required bool? isUpcoming,
           @JsonKey(name: 'is_partnership') required bool? isPartnership,
           @JsonKey(name: 'partner') required String? partner,
+          @JsonKey(name: 'area') String? area,
           @JsonKey(name: 'reward') required List<RewardModel>? reward}) =
       _VoteModel;
 

--- a/picnic_lib/lib/generated/providers/models/vote/vote.freezed.dart
+++ b/picnic_lib/lib/generated/providers/models/vote/vote.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$VoteModel {
 
-@JsonKey(name: 'id') int get id;@JsonKey(name: 'title') Map<String, dynamic> get title;@JsonKey(name: 'vote_category') String? get voteCategory;@JsonKey(name: 'main_image') String? get mainImage;@JsonKey(name: 'wait_image') String? get waitImage;@JsonKey(name: 'result_image') String? get resultImage;@JsonKey(name: 'vote_content') String? get voteContent;@JsonKey(name: 'vote_item') List<VoteItemModel>? get voteItem;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'visible_at') DateTime? get visibleAt;@JsonKey(name: 'stop_at') DateTime? get stopAt;@JsonKey(name: 'start_at') DateTime? get startAt;@JsonKey(name: 'is_ended') bool? get isEnded;@JsonKey(name: 'is_upcoming') bool? get isUpcoming;@JsonKey(name: 'is_partnership') bool? get isPartnership;@JsonKey(name: 'partner') String? get partner;@JsonKey(name: 'reward') List<RewardModel>? get reward;
+@JsonKey(name: 'id') int get id;@JsonKey(name: 'title') Map<String, dynamic> get title;@JsonKey(name: 'vote_category') String? get voteCategory;@JsonKey(name: 'main_image') String? get mainImage;@JsonKey(name: 'wait_image') String? get waitImage;@JsonKey(name: 'result_image') String? get resultImage;@JsonKey(name: 'vote_content') String? get voteContent;@JsonKey(name: 'vote_item') List<VoteItemModel>? get voteItem;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'visible_at') DateTime? get visibleAt;@JsonKey(name: 'stop_at') DateTime? get stopAt;@JsonKey(name: 'start_at') DateTime? get startAt;@JsonKey(name: 'is_ended') bool? get isEnded;@JsonKey(name: 'is_upcoming') bool? get isUpcoming;@JsonKey(name: 'is_partnership') bool? get isPartnership;@JsonKey(name: 'partner') String? get partner;@JsonKey(name: 'area') String? get area;@JsonKey(name: 'reward') List<RewardModel>? get reward;
 /// Create a copy of VoteModel
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $VoteModelCopyWith<VoteModel> get copyWith => _$VoteModelCopyWithImpl<VoteModel>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VoteModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.title, title)&&(identical(other.voteCategory, voteCategory) || other.voteCategory == voteCategory)&&(identical(other.mainImage, mainImage) || other.mainImage == mainImage)&&(identical(other.waitImage, waitImage) || other.waitImage == waitImage)&&(identical(other.resultImage, resultImage) || other.resultImage == resultImage)&&(identical(other.voteContent, voteContent) || other.voteContent == voteContent)&&const DeepCollectionEquality().equals(other.voteItem, voteItem)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.visibleAt, visibleAt) || other.visibleAt == visibleAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.isEnded, isEnded) || other.isEnded == isEnded)&&(identical(other.isUpcoming, isUpcoming) || other.isUpcoming == isUpcoming)&&(identical(other.isPartnership, isPartnership) || other.isPartnership == isPartnership)&&(identical(other.partner, partner) || other.partner == partner)&&const DeepCollectionEquality().equals(other.reward, reward));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VoteModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.title, title)&&(identical(other.voteCategory, voteCategory) || other.voteCategory == voteCategory)&&(identical(other.mainImage, mainImage) || other.mainImage == mainImage)&&(identical(other.waitImage, waitImage) || other.waitImage == waitImage)&&(identical(other.resultImage, resultImage) || other.resultImage == resultImage)&&(identical(other.voteContent, voteContent) || other.voteContent == voteContent)&&const DeepCollectionEquality().equals(other.voteItem, voteItem)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.visibleAt, visibleAt) || other.visibleAt == visibleAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.isEnded, isEnded) || other.isEnded == isEnded)&&(identical(other.isUpcoming, isUpcoming) || other.isUpcoming == isUpcoming)&&(identical(other.isPartnership, isPartnership) || other.isPartnership == isPartnership)&&(identical(other.partner, partner) || other.partner == partner)&&(identical(other.area, area) || other.area == area)&&const DeepCollectionEquality().equals(other.reward, reward));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(title),voteCategory,mainImage,waitImage,resultImage,voteContent,const DeepCollectionEquality().hash(voteItem),createdAt,visibleAt,stopAt,startAt,isEnded,isUpcoming,isPartnership,partner,const DeepCollectionEquality().hash(reward));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(title),voteCategory,mainImage,waitImage,resultImage,voteContent,const DeepCollectionEquality().hash(voteItem),createdAt,visibleAt,stopAt,startAt,isEnded,isUpcoming,isPartnership,partner,area,const DeepCollectionEquality().hash(reward));
 
 @override
 String toString() {
-  return 'VoteModel(id: $id, title: $title, voteCategory: $voteCategory, mainImage: $mainImage, waitImage: $waitImage, resultImage: $resultImage, voteContent: $voteContent, voteItem: $voteItem, createdAt: $createdAt, visibleAt: $visibleAt, stopAt: $stopAt, startAt: $startAt, isEnded: $isEnded, isUpcoming: $isUpcoming, isPartnership: $isPartnership, partner: $partner, reward: $reward)';
+  return 'VoteModel(id: $id, title: $title, voteCategory: $voteCategory, mainImage: $mainImage, waitImage: $waitImage, resultImage: $resultImage, voteContent: $voteContent, voteItem: $voteItem, createdAt: $createdAt, visibleAt: $visibleAt, stopAt: $stopAt, startAt: $startAt, isEnded: $isEnded, isUpcoming: $isUpcoming, isPartnership: $isPartnership, partner: $partner, area: $area, reward: $reward)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $VoteModelCopyWith<$Res>  {
   factory $VoteModelCopyWith(VoteModel value, $Res Function(VoteModel) _then) = _$VoteModelCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'id') int id,@JsonKey(name: 'title') Map<String, dynamic> title,@JsonKey(name: 'vote_category') String? voteCategory,@JsonKey(name: 'main_image') String? mainImage,@JsonKey(name: 'wait_image') String? waitImage,@JsonKey(name: 'result_image') String? resultImage,@JsonKey(name: 'vote_content') String? voteContent,@JsonKey(name: 'vote_item') List<VoteItemModel>? voteItem,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'visible_at') DateTime? visibleAt,@JsonKey(name: 'stop_at') DateTime? stopAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'is_ended') bool? isEnded,@JsonKey(name: 'is_upcoming') bool? isUpcoming,@JsonKey(name: 'is_partnership') bool? isPartnership,@JsonKey(name: 'partner') String? partner,@JsonKey(name: 'reward') List<RewardModel>? reward
+@JsonKey(name: 'id') int id,@JsonKey(name: 'title') Map<String, dynamic> title,@JsonKey(name: 'vote_category') String? voteCategory,@JsonKey(name: 'main_image') String? mainImage,@JsonKey(name: 'wait_image') String? waitImage,@JsonKey(name: 'result_image') String? resultImage,@JsonKey(name: 'vote_content') String? voteContent,@JsonKey(name: 'vote_item') List<VoteItemModel>? voteItem,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'visible_at') DateTime? visibleAt,@JsonKey(name: 'stop_at') DateTime? stopAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'is_ended') bool? isEnded,@JsonKey(name: 'is_upcoming') bool? isUpcoming,@JsonKey(name: 'is_partnership') bool? isPartnership,@JsonKey(name: 'partner') String? partner,@JsonKey(name: 'area') String? area,@JsonKey(name: 'reward') List<RewardModel>? reward
 });
 
 
@@ -65,7 +65,7 @@ class _$VoteModelCopyWithImpl<$Res>
 
 /// Create a copy of VoteModel
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? voteCategory = freezed,Object? mainImage = freezed,Object? waitImage = freezed,Object? resultImage = freezed,Object? voteContent = freezed,Object? voteItem = freezed,Object? createdAt = freezed,Object? visibleAt = freezed,Object? stopAt = freezed,Object? startAt = freezed,Object? isEnded = freezed,Object? isUpcoming = freezed,Object? isPartnership = freezed,Object? partner = freezed,Object? reward = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? voteCategory = freezed,Object? mainImage = freezed,Object? waitImage = freezed,Object? resultImage = freezed,Object? voteContent = freezed,Object? voteItem = freezed,Object? createdAt = freezed,Object? visibleAt = freezed,Object? stopAt = freezed,Object? startAt = freezed,Object? isEnded = freezed,Object? isUpcoming = freezed,Object? isPartnership = freezed,Object? partner = freezed,Object? area = freezed,Object? reward = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
@@ -83,6 +83,7 @@ as DateTime?,isEnded: freezed == isEnded ? _self.isEnded : isEnded // ignore: ca
 as bool?,isUpcoming: freezed == isUpcoming ? _self.isUpcoming : isUpcoming // ignore: cast_nullable_to_non_nullable
 as bool?,isPartnership: freezed == isPartnership ? _self.isPartnership : isPartnership // ignore: cast_nullable_to_non_nullable
 as bool?,partner: freezed == partner ? _self.partner : partner // ignore: cast_nullable_to_non_nullable
+as String?,area: freezed == area ? _self.area : area // ignore: cast_nullable_to_non_nullable
 as String?,reward: freezed == reward ? _self.reward : reward // ignore: cast_nullable_to_non_nullable
 as List<RewardModel>?,
   ));
@@ -169,10 +170,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  int id, @JsonKey(name: 'title')  Map<String, dynamic> title, @JsonKey(name: 'vote_category')  String? voteCategory, @JsonKey(name: 'main_image')  String? mainImage, @JsonKey(name: 'wait_image')  String? waitImage, @JsonKey(name: 'result_image')  String? resultImage, @JsonKey(name: 'vote_content')  String? voteContent, @JsonKey(name: 'vote_item')  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'visible_at')  DateTime? visibleAt, @JsonKey(name: 'stop_at')  DateTime? stopAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'is_ended')  bool? isEnded, @JsonKey(name: 'is_upcoming')  bool? isUpcoming, @JsonKey(name: 'is_partnership')  bool? isPartnership, @JsonKey(name: 'partner')  String? partner, @JsonKey(name: 'reward')  List<RewardModel>? reward)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  int id, @JsonKey(name: 'title')  Map<String, dynamic> title, @JsonKey(name: 'vote_category')  String? voteCategory, @JsonKey(name: 'main_image')  String? mainImage, @JsonKey(name: 'wait_image')  String? waitImage, @JsonKey(name: 'result_image')  String? resultImage, @JsonKey(name: 'vote_content')  String? voteContent, @JsonKey(name: 'vote_item')  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'visible_at')  DateTime? visibleAt, @JsonKey(name: 'stop_at')  DateTime? stopAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'is_ended')  bool? isEnded, @JsonKey(name: 'is_upcoming')  bool? isUpcoming, @JsonKey(name: 'is_partnership')  bool? isPartnership, @JsonKey(name: 'partner')  String? partner, @JsonKey(name: 'area')  String? area, @JsonKey(name: 'reward')  List<RewardModel>? reward)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VoteModel() when $default != null:
-return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.waitImage,_that.resultImage,_that.voteContent,_that.voteItem,_that.createdAt,_that.visibleAt,_that.stopAt,_that.startAt,_that.isEnded,_that.isUpcoming,_that.isPartnership,_that.partner,_that.reward);case _:
+return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.waitImage,_that.resultImage,_that.voteContent,_that.voteItem,_that.createdAt,_that.visibleAt,_that.stopAt,_that.startAt,_that.isEnded,_that.isUpcoming,_that.isPartnership,_that.partner,_that.area,_that.reward);case _:
   return orElse();
 
 }
@@ -190,10 +191,10 @@ return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.wa
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  int id, @JsonKey(name: 'title')  Map<String, dynamic> title, @JsonKey(name: 'vote_category')  String? voteCategory, @JsonKey(name: 'main_image')  String? mainImage, @JsonKey(name: 'wait_image')  String? waitImage, @JsonKey(name: 'result_image')  String? resultImage, @JsonKey(name: 'vote_content')  String? voteContent, @JsonKey(name: 'vote_item')  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'visible_at')  DateTime? visibleAt, @JsonKey(name: 'stop_at')  DateTime? stopAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'is_ended')  bool? isEnded, @JsonKey(name: 'is_upcoming')  bool? isUpcoming, @JsonKey(name: 'is_partnership')  bool? isPartnership, @JsonKey(name: 'partner')  String? partner, @JsonKey(name: 'reward')  List<RewardModel>? reward)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'id')  int id, @JsonKey(name: 'title')  Map<String, dynamic> title, @JsonKey(name: 'vote_category')  String? voteCategory, @JsonKey(name: 'main_image')  String? mainImage, @JsonKey(name: 'wait_image')  String? waitImage, @JsonKey(name: 'result_image')  String? resultImage, @JsonKey(name: 'vote_content')  String? voteContent, @JsonKey(name: 'vote_item')  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'visible_at')  DateTime? visibleAt, @JsonKey(name: 'stop_at')  DateTime? stopAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'is_ended')  bool? isEnded, @JsonKey(name: 'is_upcoming')  bool? isUpcoming, @JsonKey(name: 'is_partnership')  bool? isPartnership, @JsonKey(name: 'partner')  String? partner, @JsonKey(name: 'area')  String? area, @JsonKey(name: 'reward')  List<RewardModel>? reward)  $default,) {final _that = this;
 switch (_that) {
 case _VoteModel():
-return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.waitImage,_that.resultImage,_that.voteContent,_that.voteItem,_that.createdAt,_that.visibleAt,_that.stopAt,_that.startAt,_that.isEnded,_that.isUpcoming,_that.isPartnership,_that.partner,_that.reward);case _:
+return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.waitImage,_that.resultImage,_that.voteContent,_that.voteItem,_that.createdAt,_that.visibleAt,_that.stopAt,_that.startAt,_that.isEnded,_that.isUpcoming,_that.isPartnership,_that.partner,_that.area,_that.reward);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -210,10 +211,10 @@ return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.wa
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'id')  int id, @JsonKey(name: 'title')  Map<String, dynamic> title, @JsonKey(name: 'vote_category')  String? voteCategory, @JsonKey(name: 'main_image')  String? mainImage, @JsonKey(name: 'wait_image')  String? waitImage, @JsonKey(name: 'result_image')  String? resultImage, @JsonKey(name: 'vote_content')  String? voteContent, @JsonKey(name: 'vote_item')  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'visible_at')  DateTime? visibleAt, @JsonKey(name: 'stop_at')  DateTime? stopAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'is_ended')  bool? isEnded, @JsonKey(name: 'is_upcoming')  bool? isUpcoming, @JsonKey(name: 'is_partnership')  bool? isPartnership, @JsonKey(name: 'partner')  String? partner, @JsonKey(name: 'reward')  List<RewardModel>? reward)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'id')  int id, @JsonKey(name: 'title')  Map<String, dynamic> title, @JsonKey(name: 'vote_category')  String? voteCategory, @JsonKey(name: 'main_image')  String? mainImage, @JsonKey(name: 'wait_image')  String? waitImage, @JsonKey(name: 'result_image')  String? resultImage, @JsonKey(name: 'vote_content')  String? voteContent, @JsonKey(name: 'vote_item')  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'visible_at')  DateTime? visibleAt, @JsonKey(name: 'stop_at')  DateTime? stopAt, @JsonKey(name: 'start_at')  DateTime? startAt, @JsonKey(name: 'is_ended')  bool? isEnded, @JsonKey(name: 'is_upcoming')  bool? isUpcoming, @JsonKey(name: 'is_partnership')  bool? isPartnership, @JsonKey(name: 'partner')  String? partner, @JsonKey(name: 'area')  String? area, @JsonKey(name: 'reward')  List<RewardModel>? reward)?  $default,) {final _that = this;
 switch (_that) {
 case _VoteModel() when $default != null:
-return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.waitImage,_that.resultImage,_that.voteContent,_that.voteItem,_that.createdAt,_that.visibleAt,_that.stopAt,_that.startAt,_that.isEnded,_that.isUpcoming,_that.isPartnership,_that.partner,_that.reward);case _:
+return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.waitImage,_that.resultImage,_that.voteContent,_that.voteItem,_that.createdAt,_that.visibleAt,_that.stopAt,_that.startAt,_that.isEnded,_that.isUpcoming,_that.isPartnership,_that.partner,_that.area,_that.reward);case _:
   return null;
 
 }
@@ -225,7 +226,7 @@ return $default(_that.id,_that.title,_that.voteCategory,_that.mainImage,_that.wa
 @JsonSerializable()
 
 class _VoteModel extends VoteModel {
-  const _VoteModel({@JsonKey(name: 'id') required this.id, @JsonKey(name: 'title') required final  Map<String, dynamic> title, @JsonKey(name: 'vote_category') required this.voteCategory, @JsonKey(name: 'main_image') required this.mainImage, @JsonKey(name: 'wait_image') required this.waitImage, @JsonKey(name: 'result_image') required this.resultImage, @JsonKey(name: 'vote_content') required this.voteContent, @JsonKey(name: 'vote_item') required final  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'visible_at') required this.visibleAt, @JsonKey(name: 'stop_at') required this.stopAt, @JsonKey(name: 'start_at') required this.startAt, @JsonKey(name: 'is_ended') required this.isEnded, @JsonKey(name: 'is_upcoming') required this.isUpcoming, @JsonKey(name: 'is_partnership') required this.isPartnership, @JsonKey(name: 'partner') required this.partner, @JsonKey(name: 'reward') required final  List<RewardModel>? reward}): _title = title,_voteItem = voteItem,_reward = reward,super._();
+  const _VoteModel({@JsonKey(name: 'id') required this.id, @JsonKey(name: 'title') required final  Map<String, dynamic> title, @JsonKey(name: 'vote_category') required this.voteCategory, @JsonKey(name: 'main_image') required this.mainImage, @JsonKey(name: 'wait_image') required this.waitImage, @JsonKey(name: 'result_image') required this.resultImage, @JsonKey(name: 'vote_content') required this.voteContent, @JsonKey(name: 'vote_item') required final  List<VoteItemModel>? voteItem, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'visible_at') required this.visibleAt, @JsonKey(name: 'stop_at') required this.stopAt, @JsonKey(name: 'start_at') required this.startAt, @JsonKey(name: 'is_ended') required this.isEnded, @JsonKey(name: 'is_upcoming') required this.isUpcoming, @JsonKey(name: 'is_partnership') required this.isPartnership, @JsonKey(name: 'partner') required this.partner, @JsonKey(name: 'area') this.area, @JsonKey(name: 'reward') required final  List<RewardModel>? reward}): _title = title,_voteItem = voteItem,_reward = reward,super._();
   factory _VoteModel.fromJson(Map<String, dynamic> json) => _$VoteModelFromJson(json);
 
 @override@JsonKey(name: 'id') final  int id;
@@ -258,6 +259,7 @@ class _VoteModel extends VoteModel {
 @override@JsonKey(name: 'is_upcoming') final  bool? isUpcoming;
 @override@JsonKey(name: 'is_partnership') final  bool? isPartnership;
 @override@JsonKey(name: 'partner') final  String? partner;
+@override@JsonKey(name: 'area') final  String? area;
  final  List<RewardModel>? _reward;
 @override@JsonKey(name: 'reward') List<RewardModel>? get reward {
   final value = _reward;
@@ -281,16 +283,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VoteModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._title, _title)&&(identical(other.voteCategory, voteCategory) || other.voteCategory == voteCategory)&&(identical(other.mainImage, mainImage) || other.mainImage == mainImage)&&(identical(other.waitImage, waitImage) || other.waitImage == waitImage)&&(identical(other.resultImage, resultImage) || other.resultImage == resultImage)&&(identical(other.voteContent, voteContent) || other.voteContent == voteContent)&&const DeepCollectionEquality().equals(other._voteItem, _voteItem)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.visibleAt, visibleAt) || other.visibleAt == visibleAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.isEnded, isEnded) || other.isEnded == isEnded)&&(identical(other.isUpcoming, isUpcoming) || other.isUpcoming == isUpcoming)&&(identical(other.isPartnership, isPartnership) || other.isPartnership == isPartnership)&&(identical(other.partner, partner) || other.partner == partner)&&const DeepCollectionEquality().equals(other._reward, _reward));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VoteModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._title, _title)&&(identical(other.voteCategory, voteCategory) || other.voteCategory == voteCategory)&&(identical(other.mainImage, mainImage) || other.mainImage == mainImage)&&(identical(other.waitImage, waitImage) || other.waitImage == waitImage)&&(identical(other.resultImage, resultImage) || other.resultImage == resultImage)&&(identical(other.voteContent, voteContent) || other.voteContent == voteContent)&&const DeepCollectionEquality().equals(other._voteItem, _voteItem)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.visibleAt, visibleAt) || other.visibleAt == visibleAt)&&(identical(other.stopAt, stopAt) || other.stopAt == stopAt)&&(identical(other.startAt, startAt) || other.startAt == startAt)&&(identical(other.isEnded, isEnded) || other.isEnded == isEnded)&&(identical(other.isUpcoming, isUpcoming) || other.isUpcoming == isUpcoming)&&(identical(other.isPartnership, isPartnership) || other.isPartnership == isPartnership)&&(identical(other.partner, partner) || other.partner == partner)&&(identical(other.area, area) || other.area == area)&&const DeepCollectionEquality().equals(other._reward, _reward));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_title),voteCategory,mainImage,waitImage,resultImage,voteContent,const DeepCollectionEquality().hash(_voteItem),createdAt,visibleAt,stopAt,startAt,isEnded,isUpcoming,isPartnership,partner,const DeepCollectionEquality().hash(_reward));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_title),voteCategory,mainImage,waitImage,resultImage,voteContent,const DeepCollectionEquality().hash(_voteItem),createdAt,visibleAt,stopAt,startAt,isEnded,isUpcoming,isPartnership,partner,area,const DeepCollectionEquality().hash(_reward));
 
 @override
 String toString() {
-  return 'VoteModel(id: $id, title: $title, voteCategory: $voteCategory, mainImage: $mainImage, waitImage: $waitImage, resultImage: $resultImage, voteContent: $voteContent, voteItem: $voteItem, createdAt: $createdAt, visibleAt: $visibleAt, stopAt: $stopAt, startAt: $startAt, isEnded: $isEnded, isUpcoming: $isUpcoming, isPartnership: $isPartnership, partner: $partner, reward: $reward)';
+  return 'VoteModel(id: $id, title: $title, voteCategory: $voteCategory, mainImage: $mainImage, waitImage: $waitImage, resultImage: $resultImage, voteContent: $voteContent, voteItem: $voteItem, createdAt: $createdAt, visibleAt: $visibleAt, stopAt: $stopAt, startAt: $startAt, isEnded: $isEnded, isUpcoming: $isUpcoming, isPartnership: $isPartnership, partner: $partner, area: $area, reward: $reward)';
 }
 
 
@@ -301,7 +303,7 @@ abstract mixin class _$VoteModelCopyWith<$Res> implements $VoteModelCopyWith<$Re
   factory _$VoteModelCopyWith(_VoteModel value, $Res Function(_VoteModel) _then) = __$VoteModelCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'id') int id,@JsonKey(name: 'title') Map<String, dynamic> title,@JsonKey(name: 'vote_category') String? voteCategory,@JsonKey(name: 'main_image') String? mainImage,@JsonKey(name: 'wait_image') String? waitImage,@JsonKey(name: 'result_image') String? resultImage,@JsonKey(name: 'vote_content') String? voteContent,@JsonKey(name: 'vote_item') List<VoteItemModel>? voteItem,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'visible_at') DateTime? visibleAt,@JsonKey(name: 'stop_at') DateTime? stopAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'is_ended') bool? isEnded,@JsonKey(name: 'is_upcoming') bool? isUpcoming,@JsonKey(name: 'is_partnership') bool? isPartnership,@JsonKey(name: 'partner') String? partner,@JsonKey(name: 'reward') List<RewardModel>? reward
+@JsonKey(name: 'id') int id,@JsonKey(name: 'title') Map<String, dynamic> title,@JsonKey(name: 'vote_category') String? voteCategory,@JsonKey(name: 'main_image') String? mainImage,@JsonKey(name: 'wait_image') String? waitImage,@JsonKey(name: 'result_image') String? resultImage,@JsonKey(name: 'vote_content') String? voteContent,@JsonKey(name: 'vote_item') List<VoteItemModel>? voteItem,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'visible_at') DateTime? visibleAt,@JsonKey(name: 'stop_at') DateTime? stopAt,@JsonKey(name: 'start_at') DateTime? startAt,@JsonKey(name: 'is_ended') bool? isEnded,@JsonKey(name: 'is_upcoming') bool? isUpcoming,@JsonKey(name: 'is_partnership') bool? isPartnership,@JsonKey(name: 'partner') String? partner,@JsonKey(name: 'area') String? area,@JsonKey(name: 'reward') List<RewardModel>? reward
 });
 
 
@@ -318,7 +320,7 @@ class __$VoteModelCopyWithImpl<$Res>
 
 /// Create a copy of VoteModel
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? voteCategory = freezed,Object? mainImage = freezed,Object? waitImage = freezed,Object? resultImage = freezed,Object? voteContent = freezed,Object? voteItem = freezed,Object? createdAt = freezed,Object? visibleAt = freezed,Object? stopAt = freezed,Object? startAt = freezed,Object? isEnded = freezed,Object? isUpcoming = freezed,Object? isPartnership = freezed,Object? partner = freezed,Object? reward = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? voteCategory = freezed,Object? mainImage = freezed,Object? waitImage = freezed,Object? resultImage = freezed,Object? voteContent = freezed,Object? voteItem = freezed,Object? createdAt = freezed,Object? visibleAt = freezed,Object? stopAt = freezed,Object? startAt = freezed,Object? isEnded = freezed,Object? isUpcoming = freezed,Object? isPartnership = freezed,Object? partner = freezed,Object? area = freezed,Object? reward = freezed,}) {
   return _then(_VoteModel(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self._title : title // ignore: cast_nullable_to_non_nullable
@@ -336,6 +338,7 @@ as DateTime?,isEnded: freezed == isEnded ? _self.isEnded : isEnded // ignore: ca
 as bool?,isUpcoming: freezed == isUpcoming ? _self.isUpcoming : isUpcoming // ignore: cast_nullable_to_non_nullable
 as bool?,isPartnership: freezed == isPartnership ? _self.isPartnership : isPartnership // ignore: cast_nullable_to_non_nullable
 as bool?,partner: freezed == partner ? _self.partner : partner // ignore: cast_nullable_to_non_nullable
+as String?,area: freezed == area ? _self.area : area // ignore: cast_nullable_to_non_nullable
 as String?,reward: freezed == reward ? _self._reward : reward // ignore: cast_nullable_to_non_nullable
 as List<RewardModel>?,
   ));

--- a/picnic_lib/lib/generated/providers/models/vote/vote.g.dart
+++ b/picnic_lib/lib/generated/providers/models/vote/vote.g.dart
@@ -44,6 +44,7 @@ _VoteModel _$VoteModelFromJson(Map<String, dynamic> json) => $checkedCreate(
       isUpcoming: $checkedConvert('is_upcoming', (v) => v as bool?),
       isPartnership: $checkedConvert('is_partnership', (v) => v as bool?),
       partner: $checkedConvert('partner', (v) => v as String?),
+      area: $checkedConvert('area', (v) => v as String?),
       reward: $checkedConvert(
         'reward',
         (v) => (v as List<dynamic>?)
@@ -88,6 +89,7 @@ Map<String, dynamic> _$VoteModelToJson(_VoteModel instance) =>
       'is_upcoming': instance.isUpcoming,
       'is_partnership': instance.isPartnership,
       'partner': instance.partner,
+      'area': instance.area,
       'reward': instance.reward?.map((e) => e.toJson()).toList(),
     };
 

--- a/picnic_lib/lib/generated/providers/vote_detail_provider.g.dart
+++ b/picnic_lib/lib/generated/providers/vote_detail_provider.g.dart
@@ -50,7 +50,7 @@ final class AsyncVoteDetailProvider
   }
 }
 
-String _$asyncVoteDetailHash() => r'7c1f85d5ef38e11c53a21b26182a526cff9f0511';
+String _$asyncVoteDetailHash() => r'01adee04365f9a85c253a3056c3172f816d2b8a2';
 
 final class AsyncVoteDetailFamily extends $Family
     with

--- a/picnic_lib/lib/presentation/pages/my_page/my_artist_page.dart
+++ b/picnic_lib/lib/presentation/pages/my_page/my_artist_page.dart
@@ -192,6 +192,8 @@ class _MyArtistPageState extends ConsumerState<MyArtistPage>
         hideSectionHeaderOnSearch: false,
         bookmarkSectionTitle: '북마크',
         generalSectionTitle: '전체 아티스트',
+        // 마이아티스트는 K-pop + 뮤지컬 배우 모두 노출
+        searchScope: ArtistSearchScope.kpopAndMusical,
       ),
       onBookmarkToggle: _toggleBookmark,
       onArtistTap: (artist) {

--- a/picnic_lib/lib/presentation/providers/vote_detail_provider.dart
+++ b/picnic_lib/lib/presentation/providers/vote_detail_provider.dart
@@ -35,7 +35,7 @@ class AsyncVoteDetail extends _$AsyncVoteDetail {
       final response = await supabase
           .from(voteTable)
           .select(
-            'id, main_image, title, start_at, stop_at, visible_at, vote_category, is_partnership, partner, $voteItemTable(*, artist(*, artist_group(*)), artist_group(*)), reward(*)',
+            'id, main_image, title, start_at, stop_at, visible_at, vote_category, area, is_partnership, partner, $voteItemTable(*, artist(*, artist_group(*)), artist_group(*)), reward(*)',
           )
           .eq('id', voteId)
           .single();

--- a/picnic_lib/lib/presentation/widgets/common/artist_select_list_view.dart
+++ b/picnic_lib/lib/presentation/widgets/common/artist_select_list_view.dart
@@ -25,6 +25,7 @@ class ArtistSelectConfig {
     this.emptyMessage = '등록된 아티스트가 없습니다.',
     this.searchEmptyMessageTemplate = '"{query}"에 대한 검색 결과가 없습니다.',
     this.errorMessage = '아티스트 목록을 불러오는데 실패했습니다.',
+    this.searchScope = ArtistSearchScope.kpopOnly,
   });
 
   final bool showBookmarkToggle;
@@ -34,6 +35,9 @@ class ArtistSelectConfig {
   final String emptyMessage;
   final String searchEmptyMessageTemplate;
   final String errorMessage;
+
+  /// 검색에 노출할 아티스트 범위 (K-pop만 / 뮤지컬만 / 통합).
+  final ArtistSearchScope searchScope;
 }
 
 /// 공통 아티스트 선택 리스트 뷰 위젯
@@ -169,6 +173,7 @@ class ArtistSelectListViewState extends ConsumerState<ArtistSelectListView> {
       limit: _pageSize,
       language: language,
       includeBookmarks: true,
+      scope: widget.config.searchScope,
     );
 
     logger.d('Received ${newItems.length} items for page $pageKey');

--- a/picnic_lib/lib/presentation/widgets/vote/vote_item_request/vote_item_request_dialog.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/vote_item_request/vote_item_request_dialog.dart
@@ -71,8 +71,11 @@ class _VoteItemRequestDialogState extends ConsumerState<VoteItemRequestDialog> {
   @override
   void initState() {
     super.initState();
-    _service =
-        VoteItemRequestService(ref: ref, voteId: widget.vote.id.toString());
+    _service = VoteItemRequestService(
+      ref: ref,
+      voteId: widget.vote.id.toString(),
+      voteArea: widget.vote.area,
+    );
     _loadAllApplicationData();
     // 초기에는 아티스트 목록 로드하지 않음
   }

--- a/picnic_lib/lib/presentation/widgets/vote/vote_item_request/vote_item_request_service.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/vote_item_request/vote_item_request_service.dart
@@ -15,10 +15,14 @@ class VoteItemRequestService {
   final WidgetRef ref;
   final String voteId;
 
+  /// 투표 area 에 따른 아티스트 검색 범위 (musical 투표 → 뮤지컬 배우 검색).
+  final ArtistSearchScope artistScope;
+
   VoteItemRequestService({
     required this.ref,
     required this.voteId,
-  });
+    String? voteArea,
+  }) : artistScope = artistSearchScopeForVoteArea(voteArea);
 
   /// 신청 수 및 사용자 신청 내역 로드
   Future<Map<String, dynamic>> loadApplicationCounts(String? userId) async {
@@ -106,11 +110,12 @@ class VoteItemRequestService {
     required int pageSize,
   }) async {
     try {
-      // 투표 후보 신청용 빠른 검색 메서드 사용
+      // 투표 후보 신청용 빠른 검색 메서드 사용 (투표 area 에 맞는 검색 범위 적용)
       final artists = await SearchService.searchArtistsFast(
         query: query,
         page: page,
         limit: pageSize,
+        scope: artistScope,
       );
 
       // 더 많은 결과가 있는지는 단순히 결과 개수로 판단

--- a/picnic_lib/test/core/services/artist_search_scope_test.dart
+++ b/picnic_lib/test/core/services/artist_search_scope_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:picnic_lib/core/services/search_service.dart';
+import 'package:picnic_lib/data/models/vote/vote.dart';
+
+/// 뮤지컬 배우(is_musical=true) 노출 회귀 가드.
+///
+/// 마이아티스트/후보요청 검색에서 뮤지컬 배우가 사라졌던 버그는
+/// 검색 쿼리가 `is_kpop=true` 만 필터하던 것이 원인이었다. 이 테스트는
+/// area→검색범위, 검색범위→PostgREST 필터 매핑이 깨지지 않도록 고정한다.
+void main() {
+  group('artistSearchScopeForVoteArea', () {
+    test('musical 투표는 뮤지컬 배우만(musicalOnly) 검색', () {
+      expect(
+        artistSearchScopeForVoteArea('musical'),
+        ArtistSearchScope.musicalOnly,
+      );
+    });
+
+    test('kpop 투표는 K-pop만(kpopOnly) 검색', () {
+      expect(
+        artistSearchScopeForVoteArea('kpop'),
+        ArtistSearchScope.kpopOnly,
+      );
+    });
+
+    test('area 가 null/미상이면 기존 동작(kpopOnly) 유지', () {
+      expect(artistSearchScopeForVoteArea(null), ArtistSearchScope.kpopOnly);
+      expect(artistSearchScopeForVoteArea(''), ArtistSearchScope.kpopOnly);
+      expect(artistSearchScopeForVoteArea('etc'), ArtistSearchScope.kpopOnly);
+    });
+  });
+
+  group('artistScopeOrFilter (PostgREST or= 필터)', () {
+    test('kpopOnly → is_kpop 만', () {
+      expect(
+        artistScopeOrFilter(ArtistSearchScope.kpopOnly),
+        'is_kpop.eq.true',
+      );
+    });
+
+    test('musicalOnly → is_musical 만 (뮤지컬 배우 노출)', () {
+      expect(
+        artistScopeOrFilter(ArtistSearchScope.musicalOnly),
+        'is_musical.eq.true',
+      );
+    });
+
+    test('kpopAndMusical → is_kpop OR is_musical (마이아티스트)', () {
+      expect(
+        artistScopeOrFilter(ArtistSearchScope.kpopAndMusical),
+        'is_kpop.eq.true,is_musical.eq.true',
+      );
+    });
+  });
+
+  group('VoteModel.area 파싱', () {
+    Map<String, dynamic> baseVoteJson(String? area) => {
+          'id': 1,
+          'title': {'ko': '테스트', 'en': 'test'},
+          'vote_category': null,
+          'main_image': null,
+          'wait_image': null,
+          'result_image': null,
+          'vote_content': null,
+          'vote_item': null,
+          'created_at': null,
+          'visible_at': null,
+          'stop_at': null,
+          'start_at': null,
+          'is_ended': null,
+          'is_upcoming': null,
+          'is_partnership': null,
+          'partner': null,
+          'area': ?area,
+          'reward': null,
+        };
+
+    test('area=musical 가 모델로 파싱됨', () {
+      expect(VoteModel.fromJson(baseVoteJson('musical')).area, 'musical');
+    });
+
+    test('area 누락 시 null (하위 호환)', () {
+      expect(VoteModel.fromJson(baseVoteJson(null)).area, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 문제 (앱 이슈 1·2)
1. 마이아티스트 검색에 **뮤지컬 배우가 안 나옴**
2. 투표 후보 요청 검색에도 **뮤지컬 배우가 안 나옴**

## 근본 원인
공용 검색 헬퍼 `SearchService.searchArtistsFast` 가 모든 쿼리 분기에 `.eq('is_kpop', true)` 를 하드코딩 → `is_kpop=false` 인 뮤지컬 배우(production 781명)가 DB 쿼리 단계에서 배제됨. 백엔드(artist-api/RPC)·anti-abuse 트리거에는 플래그 필터가 없어 순수 클라이언트 원인.

## 수정
- `ArtistSearchScope { kpopOnly, musicalOnly, kpopAndMusical }` enum + `artistSearchScopeForVoteArea` / `artistScopeOrFilter` 매핑 함수 도입
- `searchArtistsFast` 를 `scope` 파라미터화 (default `kpopOnly` 로 기존 동작 보존, **캐시 키에 scope 포함**)
- **이슈1 마이아티스트**: `kpopAndMusical` (kpop + 뮤지컬 통합)
- **이슈2 후보요청**: `VoteModel.area` 연동 → `musical` 투표는 뮤지컬 배우만, `kpop` 투표는 기존대로 (**kpop 투표에 뮤지컬 누출 없음**)
- `VoteModel` 에 `area`(optional nullable) 추가 + `vote_detail_provider` select 에 `area` 포함 (`vote`/`pic_vote` 둘 다 컬럼 보유 확인)
- 기존 default 호출처(궁합 선택 등) 동작 불변

## 검증
- `flutter analyze` 변경 파일 clean, 전체 lib 신규 에러 0건
- 신규 단위테스트 8개 + 기존 search_service 테스트 169개 통과 (회귀 없음)
- postgrest 2.7.0: `.or()` 다중 호출 = `or=` 다중 파라미터 → AND 결합 확인 (텍스트 검색 정확)
- production DB 동등 쿼리: 마이아티스트 뮤지컬 781명 노출 / 뮤지컬투표 검색 정상 / kpop투표 누출 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)