### PR TITLE
feat(device-fingerprint): Android device_hash를 SSAID 기반으로 (재설치 견딤)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-android-ssaid-device-hash.md
+++ b/docs/superpowers/plans/2026-06-08-android-ssaid-device-hash.md
@@ -1,0 +1,356 @@
+# Android SSAID device_hash Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Android `device_hash` 를 재설치를 견디는 `Settings.Secure.ANDROID_ID`(SSAID) 기반으로 바꿔, device 코호트 신호의 재설치-우회를 줄인다.
+
+**Architecture:** client-only 변경. 순수 헬퍼(`DeviceFingerprintHelper`)에 SSAID 검증·해싱 함수를 추가해 단위테스트로 고정하고, `DeviceFingerprint.getDeviceId()` 는 Android 에서 SSAID 를 우선 사용하고 무효 시 기존 UUID 흐름으로 폴백하는 얇은 글루만 둔다. 서버/DB/edge-fn 무변경.
+
+**Tech Stack:** Flutter / Dart, `android_id` 플러그인, `crypto`(SHA-256), `flutter_secure_storage`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-android-ssaid-device-hash-design.md`
+
+**Worktree:** `~/Repositories/picnic-app-android-ssaid` (branch `feat/android-ssaid-device-hash`)
+
+---
+
+## File Structure
+
+- `picnic_lib/pubspec.yaml` — `android_id` 의존성 추가
+- `picnic_lib/lib/core/utils/device_fingerprint_helper.dart` — 순수 함수 `normalizeAndroidId`, `hashAndroidId` 추가
+- `picnic_lib/lib/core/utils/device_fingerprint.dart` — `getDeviceId()` Android 분기 + 기존 UUID 로직을 `_getOrCreateUuid()` 로 추출
+- `picnic_lib/test/core/utils/device_fingerprint_helper_test.dart` — 신규 함수 단위테스트 추가
+
+작업 순서: 의존성 → 순수 헬퍼(TDD) → 글루 → 수동 검증.
+
+---
+
+### Task 1: `android_id` 의존성 추가
+
+**Files:**
+- Modify: `picnic_lib/pubspec.yaml` (dependencies 섹션, `device_info_plus:` 인근)
+
+- [ ] **Step 1: 의존성 추가**
+
+`picnic_lib/` 에서 실행 (최신 호환 버전 자동 해결):
+
+```bash
+cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter pub add android_id
+```
+
+Expected: `pubspec.yaml` 의 dependencies 에 `android_id: ^x.y.z` 가 추가되고 `flutter pub get` 이 성공.
+
+- [ ] **Step 2: 해결 확인**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && grep android_id pubspec.yaml`
+Expected: `  android_id: ^...` 한 줄 출력.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Repositories/picnic-app-android-ssaid
+git add picnic_lib/pubspec.yaml picnic_lib/pubspec.lock
+git commit -m "chore(device-fingerprint): add android_id dependency for SSAID"
+```
+
+---
+
+### Task 2: `normalizeAndroidId` 순수 함수 (TDD)
+
+SSAID 문자열을 검증·정규화한다. 무효이면 `null`.
+
+**Files:**
+- Test: `picnic_lib/test/core/utils/device_fingerprint_helper_test.dart`
+- Modify: `picnic_lib/lib/core/utils/device_fingerprint_helper.dart`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`device_fingerprint_helper_test.dart` 의 `group('DeviceFingerprintHelper', () { ... })` 안에 아래 그룹을 추가:
+
+```dart
+    group('normalizeAndroidId', () {
+      test('returns null for null input', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId(null), isNull);
+      });
+
+      test('returns null for empty / whitespace input', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId(''), isNull);
+        expect(DeviceFingerprintHelper.normalizeAndroidId('   '), isNull);
+      });
+
+      test('returns null for known-bad constant 9774d56d682e549c', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('9774d56d682e549c'),
+          isNull,
+        );
+        // 대문자로 와도 정규화 후 동일하게 거부
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('9774D56D682E549C'),
+          isNull,
+        );
+      });
+
+      test('returns null for non-hex input', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId('xyz123hello'), isNull);
+      });
+
+      test('returns null for too-short input (< 8 chars)', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId('a1b2'), isNull);
+      });
+
+      test('lowercases and returns a valid 16-hex SSAID', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('ABCDEF0123456789'),
+          'abcdef0123456789',
+        );
+      });
+
+      test('trims surrounding whitespace before validating', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('  dca8e4f1b2c3d4e5  '),
+          'dca8e4f1b2c3d4e5',
+        );
+      });
+    });
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter test test/core/utils/device_fingerprint_helper_test.dart`
+Expected: FAIL — `The method 'normalizeAndroidId' isn't defined for the type 'DeviceFingerprintHelper'`.
+
+- [ ] **Step 3: 최소 구현**
+
+`device_fingerprint_helper.dart` 의 `class DeviceFingerprintHelper {` 안에 추가 (`generateHash` 아래 권장):
+
+```dart
+  /// 알려진 불량 SSAID 상수 — 일부 구형 단말이 하드코딩 반환하던 값.
+  static const String _badAndroidId = '9774d56d682e549c';
+  static final RegExp _hexOnly = RegExp(r'^[0-9a-f]+$');
+
+  /// SSAID(Settings.Secure.ANDROID_ID) 를 검증·정규화한다.
+  ///
+  /// 규칙: trim + 소문자화 → 빈값 / 불량상수 / 비-hex / 8자 미만은 무효(null).
+  /// SSAID 는 통상 16자 hex 지만 leading-zero 등으로 짧게 렌더될 수 있어
+  /// 상한은 강제하지 않는다(유효값 over-reject 방지).
+  static String? normalizeAndroidId(String? ssaid) {
+    if (ssaid == null) return null;
+    final v = ssaid.trim().toLowerCase();
+    if (v.isEmpty) return null;
+    if (v == _badAndroidId) return null;
+    if (v.length < 8) return null;
+    if (!_hexOnly.hasMatch(v)) return null;
+    return v;
+  }
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter test test/core/utils/device_fingerprint_helper_test.dart`
+Expected: PASS (전체 그린).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Repositories/picnic-app-android-ssaid
+git add picnic_lib/lib/core/utils/device_fingerprint_helper.dart picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
+git commit -m "feat(device-fingerprint): add normalizeAndroidId validator"
+```
+
+---
+
+### Task 3: `hashAndroidId` 순수 함수 (TDD)
+
+정규화된 SSAID 를 네임스페이스 prefix 와 함께 SHA-256 해싱.
+
+**Files:**
+- Test: `picnic_lib/test/core/utils/device_fingerprint_helper_test.dart`
+- Modify: `picnic_lib/lib/core/utils/device_fingerprint_helper.dart`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+같은 테스트 파일에 그룹 추가 (파일 상단에 이미 `import 'dart:convert';` 와 `import 'package:crypto/crypto.dart';` 존재 — 그대로 사용):
+
+```dart
+    group('hashAndroidId', () {
+      test('is deterministic for the same input', () {
+        final a = DeviceFingerprintHelper.hashAndroidId('abcdef0123456789');
+        final b = DeviceFingerprintHelper.hashAndroidId('abcdef0123456789');
+        expect(a, b);
+      });
+
+      test('returns a 64-char lowercase hex string', () {
+        final h = DeviceFingerprintHelper.hashAndroidId('abcdef0123456789');
+        expect(h.length, 64);
+        expect(RegExp(r'^[0-9a-f]{64}$').hasMatch(h), isTrue);
+      });
+
+      test('equals SHA-256 of the namespaced string', () {
+        const id = 'abcdef0123456789';
+        final expected =
+            sha256.convert(utf8.encode('picnic.android_id:$id')).toString();
+        expect(DeviceFingerprintHelper.hashAndroidId(id), expected);
+      });
+
+      test('namespace makes it differ from a raw SHA-256 of the id', () {
+        const id = 'abcdef0123456789';
+        final raw = sha256.convert(utf8.encode(id)).toString();
+        expect(DeviceFingerprintHelper.hashAndroidId(id), isNot(raw));
+      });
+    });
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter test test/core/utils/device_fingerprint_helper_test.dart`
+Expected: FAIL — `The method 'hashAndroidId' isn't defined`.
+
+- [ ] **Step 3: 최소 구현**
+
+`device_fingerprint_helper.dart` 의 클래스 안에 추가 (`normalizeAndroidId` 아래):
+
+```dart
+  /// device_hash 네임스페이스 prefix — raw SSAID 역산/타시스템 상관 방지.
+  static const String _androidIdNamespace = 'picnic.android_id:';
+
+  /// 정규화된 SSAID 를 네임스페이스와 함께 SHA-256 한 64-hex 문자열 반환.
+  /// 입력은 [normalizeAndroidId] 를 통과한 값이어야 한다.
+  static String hashAndroidId(String normalizedSsaid) {
+    final bytes = utf8.encode('$_androidIdNamespace$normalizedSsaid');
+    return sha256.convert(bytes).toString();
+  }
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter test test/core/utils/device_fingerprint_helper_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Repositories/picnic-app-android-ssaid
+git add picnic_lib/lib/core/utils/device_fingerprint_helper.dart picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
+git commit -m "feat(device-fingerprint): add namespaced hashAndroidId"
+```
+
+---
+
+### Task 4: `getDeviceId()` Android SSAID 분기
+
+기존 UUID 로직을 `_getOrCreateUuid()` 로 추출하고, Android 에서 유효 SSAID 가 있으면 그 해시를 우선 반환.
+
+**Files:**
+- Modify: `picnic_lib/lib/core/utils/device_fingerprint.dart`
+
+- [ ] **Step 1: import 추가**
+
+`device_fingerprint.dart` 상단 import 블록에 추가:
+
+```dart
+import 'package:android_id/android_id.dart';
+```
+
+- [ ] **Step 2: 기존 UUID 로직을 `_getOrCreateUuid()` 로 추출**
+
+현재 `getDeviceId()` 본문(우선순위 1~3: v2 키 → legacy 마이그레이션 → fresh)을 그대로 새 private 메서드로 옮긴다. 클래스 안에 추가:
+
+```dart
+  /// v2 UUID 우선 → legacy 강제 마이그레이션 → fresh UUID.
+  /// (Android SSAID 무효 시 폴백, iOS 기본 경로.)
+  static Future<String> _getOrCreateUuid() async {
+    final uuid = await _storage.read(key: _uuidVersionKey);
+    if (uuid != null && uuid.isNotEmpty) {
+      return uuid;
+    }
+
+    final legacy = await _storage.read(key: _fingerprintKey);
+    if (legacy != null && legacy.isNotEmpty) {
+      final migrated = _uuidGen.v4();
+      await _storage.write(key: _uuidVersionKey, value: migrated);
+      await _storage.delete(key: _fingerprintKey);
+      return migrated;
+    }
+
+    final fresh = _uuidGen.v4();
+    await _storage.write(key: _uuidVersionKey, value: fresh);
+    return fresh;
+  }
+```
+
+- [ ] **Step 3: `getDeviceId()` 를 Android 분기 + 폴백으로 교체**
+
+`getDeviceId()` 본문 전체를 아래로 교체 (doc 주석은 유지/보강):
+
+```dart
+  /// 기기 식별자.
+  ///
+  /// Android: SSAID(Settings.Secure.ANDROID_ID) 가 유효하면 그 해시를 우선 반환한다.
+  ///   - SSAID 는 재설치/업데이트를 견디고(공장초기화만 리셋) 기종/펌웨어에서 파생되지
+  ///     않아 collision 이 없다. stored UUID 보다 우선해야 기존 유저도 업그레이드된다.
+  ///   - 해시는 저장하지 않는다(결정적이라 재계산해도 동일). SSAID 무효(에뮬레이터 등)면
+  ///     기존 UUID 흐름으로 폴백한다.
+  /// iOS: 기존 UUID 흐름(Keychain 이 재설치를 견딤).
+  static Future<String> getDeviceId() async {
+    if (UniversalPlatform.isAndroid) {
+      final ssaid = await const AndroidId().getId();
+      final norm = DeviceFingerprintHelper.normalizeAndroidId(ssaid);
+      if (norm != null) {
+        return DeviceFingerprintHelper.hashAndroidId(norm);
+      }
+      // SSAID 무효 → 아래 UUID 폴백
+    }
+    return _getOrCreateUuid();
+  }
+```
+
+- [ ] **Step 4: 정적 분석 + 기존 테스트 회귀 확인**
+
+Run:
+```bash
+cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter analyze lib/core/utils/device_fingerprint.dart && flutter test test/core/utils/device_fingerprint_test.dart test/core/utils/device_fingerprint_helper_test.dart
+```
+Expected: analyze 무경고(신규 import 사용됨), 기존 `device_fingerprint_test.dart` 그린(회귀 없음).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Repositories/picnic-app-android-ssaid
+git add picnic_lib/lib/core/utils/device_fingerprint.dart
+git commit -m "feat(device-fingerprint): use SSAID-based hash on Android, UUID fallback"
+```
+
+---
+
+### Task 5: 수동/통합 검증 (플랫폼 채널 의존이라 단위테스트 불가)
+
+**Files:** 없음 (검증 전용)
+
+- [ ] **Step 1: 실기기(Android) 에서 동작 확인**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid && flutter run --dart-define=DISABLE_VM_CHECK=true`
+- `DeviceFingerprint.getDeviceId()` 가 64-hex 를 반환하는지(로그/디버거).
+- 앱 **삭제 후 재설치** → 같은 값이 나오는지 (SSAID 안정성).
+- (가능하면) 같은 기종 다른 단말 → 다른 값이 나오는지.
+
+- [ ] **Step 2: 에뮬레이터 폴백 확인**
+
+에뮬레이터(SSAID null 가능)에서 실행 → 크래시 없이 UUID 값으로 폴백되는지 확인.
+
+- [ ] **Step 3: 전체 테스트 스위트**
+
+Run: `cd ~/Repositories/picnic-app-android-ssaid/picnic_lib && flutter test`
+Expected: 전체 그린.
+
+---
+
+## 릴리스 주의 (구현과 별개, 배포 시)
+
+- `android_id` 는 네이티브 구현 포함 플러그인 → **Shorebird 패치 불가, 스토어 릴리스 필요** (`picnic-v*` 태그 트리거). Dart-only 가 아니므로 patch 로 내보낼 수 없음.
+- 롤아웃 시 Android 유저 device_hash 가 UUID→SSAID-hash 로 1회 변경 → cohort 1회 재흩어짐(attendance 매일이라 1~2일 재형성). 서버 무변경.
+
+## Out of scope
+
+- 서버 cohort 정책 변경(IP-cluster→suspect, IP-집중 collision 필터) — 별도 spec/plan.
+- dead build-hash 경로(`_generateFingerprint`) 제거 — 선택적.
+- iOS 변경 없음.

--- a/docs/superpowers/specs/2026-06-08-android-ssaid-device-hash-design.md
+++ b/docs/superpowers/specs/2026-06-08-android-ssaid-device-hash-design.md
@@ -98,6 +98,20 @@ iOS (그리고 Android SSAID 폴백):
 - ⚠️ **`android_id` 는 네이티브 구현을 포함한 플러그인** → **Shorebird 패치 불가, 스토어 릴리스 필요**
   (참고: Shorebird 패치는 Dart-only 변경만 가능. 새 네이티브 플러그인 추가는 full release build 대상).
 
+## device_hash 공유 소비처 영향
+
+`getDeviceId()` 의 값은 anti-abuse(`request_ip_log`) 전용이 아니라 `DeviceManager` 를 통해
+다음과도 공유된다. 전환(UUID→SSAID-hash) 시 Android 단말은 1회 새 식별자로 재등록되며, 실측상 영향은 무해하다.
+
+- **`device_bans`** (`isDeviceBanned()` — startup/login 차단 게이트): hash 변경 시 기존 기기 차단이
+  1회 매칭 해제될 수 있으나, 프로덕션에 device_bans 는 **1건(2025-02, 휴면)** 뿐이라 영향 무의미.
+  장기적으로는 ban 이 재설치-견딤이 되어 오히려 견고해짐.
+- **`devices`** (`registerDevice()` upsert `onConflict=device_id`, `updateLastSeen()`): Android 단말이
+  새 `device_id` 로 1행 추가 등록되고 옛 행은 stale 화. **기기수 제한 로직이 없어** 강제 로그아웃·한도
+  트리거 없음 — stale row 누적(데이터 위생)만 남는다.
+- **세션/로그인**: Supabase JWT 기반이라 device_hash 와 무관 → 로그아웃 영향 없음.
+- 멀쩡한 유저 오차단 없음 (새 hash 는 device_bans/anti-abuse 에서 단지 "신규"로 취급).
+
 ## 테스트
 
 - `DeviceFingerprintHelper` 의 두 신규 함수에 **순수 단위테스트**:

--- a/docs/superpowers/specs/2026-06-08-android-ssaid-device-hash-design.md
+++ b/docs/superpowers/specs/2026-06-08-android-ssaid-device-hash-design.md
@@ -1,0 +1,122 @@
+# Android device_hash → SSAID 기반 (재설치 견딤) 설계
+
+- 날짜: 2026-06-08
+- 브랜치: `feat/android-ssaid-device-hash`
+- 범위: **picnic_lib 클라이언트만.** 서버 / DB / edge-function 무변경.
+
+## 배경 / 문제
+
+anti-abuse 의 device 코호트 신호는 `request_ip_log.device_hash` 로 "한 기기에서 출석/광고한
+distinct 계정 수" 를 센다. 그런데 현재 Android `device_hash` 는 두 단계의 약점이 있다.
+
+1. **(이미 수정됨) build-metadata collision** — 과거 `device_hash` 는 `Build.*` 속성
+   (model/manufacturer/fingerprint/host 등)만 SHA-256 한 값이라, 단말 고유 엔트로피가 0 이었다.
+   같은 기종+펌웨어 단말은 글자 단위로 동일 → **동일 hash collision** → 보급 기종(갤럭시 A/S 등)에서
+   남남 수백 명이 한 hash 로 붕괴. PR #44 에서 **flutter_secure_storage 에 저장한 UUID v4** 로 전환해 해소.
+
+2. **(이번 대상) UUID 는 per-install, not per-device** — Android 는 앱 삭제 시 앱 저장소를 비우고,
+   flutter_secure_storage 의 Keystore 키는 백업으로 복원되지 않는다. 즉 **재설치하면 새 UUID** 가 발급된다.
+   → 운영자가 *계정마다 재설치* 하면 device 코호트가 아예 형성되지 않아 신호를 우회할 수 있다.
+   (iOS 는 Keychain 이 재설치를 견뎌 이미 per-device 에 가깝다 — Android 한정 문제.)
+
+## 정책 맥락 (바 A)
+
+이 변경은 "다중계정 자체를 막는다" 가 아니다. 다중계정은 정책상 허용이며, device 코호트는
+**노골적 단일-설치 운영자를 식별하는 soft triage 신호**로만 쓴다. 목표는 **best-effort 억지력** —
+재설치 우회 비용을 올리되 완벽 차단은 추구하지 않는다. enforce 의 진짜 무게는 ad_watch 사기 신호에 둔다.
+(서버측 cohort 정책 변경 — IP-cluster→suspect, IP-집중 collision 필터 — 은 **별도 spec**.)
+
+## 해결책
+
+Android `device_hash` 를 **`Settings.Secure.ANDROID_ID`(SSAID) 의 SHA-256** 으로 산출한다.
+SSAID 는 OS 가 랜덤 시드로 발급하는 (앱 서명키 × 사용자 × 기기) 고유값으로,
+**재설치·업데이트해도 유지**(공장초기화에서만 리셋)되고 기종/펌웨어에서 파생되지 않아 **collision 이 없다**.
+SSAID 가 없거나(에뮬레이터 등) 무효이면 기존 UUID 흐름으로 폴백한다.
+
+> 아이러니하게도 SSAID 는 원래 코드의 `androidId` 필드가 담았어야 할 값이다 (현재는 `Build.FINGERPRINT`
+> 가 잘못 들어가 있음). 이번 변경은 "UUID 우회" 가 아니라 원래 의도된 식별자를 올바르게 쓰는 것이다.
+
+## 컴포넌트 변경
+
+### 1. `picnic_lib/pubspec.yaml`
+- `android_id` 패키지 추가 (Dart 한 줄로 SSAID 획득, 네이티브 코드 0).
+
+### 2. `picnic_lib/lib/core/utils/device_fingerprint_helper.dart` (순수 헬퍼)
+테스트 가능한 순수 함수 2개 추가:
+
+- `static String? normalizeAndroidId(String? ssaid)`
+  - 먼저 trim + 소문자화
+  - `null` / 빈 문자열 → `null`
+  - 알려진 불량 상수 `9774d56d682e549c` → `null`
+  - hex 형태(`^[0-9a-f]+$`)가 아니거나 길이가 너무 짧으면(`< 8`, junk 가드) → `null`
+    - SSAID 는 통상 16자 hex 지만 leading-zero 등으로 짧게 렌더될 수 있어 길이 상한을 강제하지 않는다 (유효값 over-reject 방지).
+  - 통과 시 정규화된(소문자) 값 반환
+- `static String hashAndroidId(String normalizedSsaid)`
+  - `sha256("picnic.android_id:" + normalizedSsaid)` 의 hex 문자열 반환
+  - 네임스페이스 prefix 로 raw SSAID 역산/타시스템 상관 방지. 기존 `generateHash` 의 sha256 유틸 재사용.
+
+### 3. `picnic_lib/lib/core/utils/device_fingerprint.dart`
+`getDeviceId()` 우선순위 변경:
+
+```
+Android:
+  ssaid = await const AndroidId().getId()
+  norm  = DeviceFingerprintHelper.normalizeAndroidId(ssaid)
+  if norm != null:
+      return DeviceFingerprintHelper.hashAndroidId(norm)   // 저장 안 함, 재계산해도 동일
+  // norm == null → 아래 UUID 흐름으로 폴백
+iOS (그리고 Android SSAID 폴백):
+  v2 UUID 키 있으면 → 반환
+  legacy 키 있으면 → 새 UUID 발급 + legacy 삭제
+  둘 다 없으면 → fresh UUID
+```
+
+핵심 결정:
+- **SSAID 가 stored UUID 보다 우선.** 안 그러면 기존 Android 유저가 옛 UUID 에 영구 고정돼 업그레이드되지 않는다.
+- SSAID-hash 는 **저장하지 않는다.** 결정적이라 매 호출 재계산해도 같은 값이고, 저장하지 않으므로 재설치와 무관하게 동일하다.
+- 기존 stored UUID 는 삭제하지 않고 **SSAID-null 폴백 안전망**으로 남긴다 (SSAID 가 일시적으로 null 일 때 hash 가 튀지 않도록).
+
+### 4. `reset()` / `verify()`
+- `verify()` 는 `getDeviceId()` 를 호출하므로 자동으로 새 로직을 탄다.
+- `reset()` 은 저장된 키만 지운다. SSAID 기반 id 는 저장값이 아니므로 reset 후에도 동일하다
+  (= 기기 신원은 "리셋" 대상이 아니라는 의도된 동작). 이 동작을 주석으로 명시한다.
+
+## 엣지 케이스
+
+| 상황 | 동작 |
+|---|---|
+| SSAID `null` (에뮬레이터/일부 환경) | UUID 폴백 |
+| SSAID == `9774d56d682e549c` (구형 불량) | 무효 처리 → UUID 폴백 |
+| 앱 서명키 변경 (재서명) | SSAID 변경됨 → device_hash 변경 (정상 릴리스에선 비발생) |
+| 공장초기화 | 새 SSAID (best-effort 의 천장, 수용) |
+
+## 롤아웃 / 마이그레이션
+
+- 첫 실행 시 유효 SSAID 가 있는 Android 유저는 `device_hash` 가 **UUID → SSAID-hash 로 1회 변경**된다.
+  cohort 가 1회 재흩어지지만 attendance 는 매일 1회라 1~2일 내 재형성된다. 기존 24h 차단은 자연 만료.
+- 서버 / DB / edge-fn 무변경 — `request_ip_log` 가 더 안정적인 device_hash 값을 받기 시작할 뿐이다.
+- ⚠️ **`android_id` 는 네이티브 구현을 포함한 플러그인** → **Shorebird 패치 불가, 스토어 릴리스 필요**
+  (참고: Shorebird 패치는 Dart-only 변경만 가능. 새 네이티브 플러그인 추가는 full release build 대상).
+
+## 테스트
+
+- `DeviceFingerprintHelper` 의 두 신규 함수에 **순수 단위테스트**:
+  - `normalizeAndroidId`: null / 빈값 / 불량상수 / 유효값 / 대문자→소문자 정규화 / 비-hex 거부
+  - `hashAndroidId`: 결정성(같은 입력 → 같은 hash), 네임스페이스 prefix 반영, 길이 64 hex
+- `getDeviceId()` 글루는 얇게 유지 — 분기/검증 로직은 전부 순수 헬퍼에. (플러그인+저장소 의존이라
+  end-to-end 는 수동/통합 검증 대상.)
+
+## Out of scope (YAGNI)
+
+- 서버 cohort 정책 변경 (IP-cluster → suspect, IP-집중 collision 필터) — **별도 spec.**
+- dead build-hash 경로(`_generateFingerprint`) 제거 — 선택적 정리, 이번 범위 아님.
+- Play Integrity / 하드웨어 attestation 등 강한 per-device 신원 — 기각 (best-effort 기조).
+- iOS 변경 — 불필요 (Keychain UUID 가 이미 재설치 견딤).
+- install UUID 를 "재설치 횟수" 사기 신호로 별도 전송 — Client+Server 안에서 기각.
+
+## 성공 기준
+
+- 유효 SSAID 단말: 앱 **재설치 후에도 동일한 `device_hash`** 산출.
+- 같은 기종+펌웨어의 *서로 다른* 단말: **서로 다른 `device_hash`** (collision 없음).
+- SSAID 무효 단말: 기존 UUID 동작으로 회귀 (회귀 없음).
+- 순수 헬퍼 단위테스트 그린.

--- a/picnic_lib/lib/core/utils/device_fingerprint.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint.dart
@@ -90,6 +90,8 @@ class DeviceFingerprint {
   }
 
   /// 기기 지문 초기화 — legacy 와 v2 키 모두 제거.
+  /// SSAID 기반 id 는 저장값이 아니므로 reset 후에도 동일한 값이 반환된다
+  /// (기기 신원은 "리셋" 대상이 아님 — 의도된 동작).
   static Future<void> reset() async {
     await _storage.delete(key: _fingerprintKey);
     await _storage.delete(key: _uuidVersionKey);

--- a/picnic_lib/lib/core/utils/device_fingerprint.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint.dart
@@ -1,3 +1,4 @@
+import 'package:android_id/android_id.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:picnic_lib/core/utils/device_fingerprint_helper.dart';
@@ -11,22 +12,29 @@ class DeviceFingerprint {
   static final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
   static const _uuidGen = Uuid();
 
-  /// 기기 식별자 가져오기.
+  /// 기기 식별자.
   ///
-  /// v2 정책: Android 의 OS-level build fingerprint 가 같은 모델+펌웨어
-  /// 사용자 사이에 collision 을 일으켜 anti-abuse device cohort 가 FP 를
-  /// 다발 → flutter_secure_storage 에 영구 저장된 UUID v4 로 전환.
-  /// iOS 는 identifierForVendor 가 이미 vendor-unique 라 안전하지만,
-  /// 일관성 + 단일 path 위해 platform 무관 UUID 사용.
-  ///
-  /// 강제 마이그레이션 (v2):
-  ///   1. v2 키 (device_fingerprint_v2_uuid) 우선
-  ///   2. legacy 키 (device_fingerprint) 가 있으면 무조건 새 UUID 발급 + 옛 키 제거.
-  ///      build-based hash collision 즉시 해소.
-  ///      trade-off: 차단된 farm user 도 새 UUID 받아 cohort 1회 흩어짐 (attendance 매일 1회라
-  ///      다시 cohort 형성에 1-2일, farm candy 누적 미미).
-  ///   3. 둘 다 없으면 신규 UUID v4 생성.
+  /// Android: SSAID(Settings.Secure.ANDROID_ID) 가 유효하면 그 해시를 우선 반환한다.
+  ///   - SSAID 는 재설치/업데이트를 견디고(공장초기화만 리셋) 기종/펌웨어에서 파생되지
+  ///     않아 collision 이 없다. stored UUID 보다 우선해야 기존 유저도 업그레이드된다.
+  ///   - 해시는 저장하지 않는다(결정적이라 재계산해도 동일). SSAID 무효(에뮬레이터 등)면
+  ///     기존 UUID 흐름으로 폴백한다.
+  /// iOS: 기존 UUID 흐름(Keychain 이 재설치를 견딤).
   static Future<String> getDeviceId() async {
+    if (UniversalPlatform.isAndroid) {
+      final ssaid = await const AndroidId().getId();
+      final norm = DeviceFingerprintHelper.normalizeAndroidId(ssaid);
+      if (norm != null) {
+        return DeviceFingerprintHelper.hashAndroidId(norm);
+      }
+      // SSAID 무효 → 아래 UUID 폴백
+    }
+    return _getOrCreateUuid();
+  }
+
+  /// v2 UUID 우선 → legacy 강제 마이그레이션 → fresh UUID.
+  /// (Android SSAID 무효 시 폴백, iOS 기본 경로.)
+  static Future<String> _getOrCreateUuid() async {
     final uuid = await _storage.read(key: _uuidVersionKey);
     if (uuid != null && uuid.isNotEmpty) {
       return uuid;
@@ -34,7 +42,6 @@ class DeviceFingerprint {
 
     final legacy = await _storage.read(key: _fingerprintKey);
     if (legacy != null && legacy.isNotEmpty) {
-      // 강제 마이그레이션 — legacy hash 폐기, 신규 UUID.
       final migrated = _uuidGen.v4();
       await _storage.write(key: _uuidVersionKey, value: migrated);
       await _storage.delete(key: _fingerprintKey);

--- a/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
@@ -1,13 +1,11 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
-import 'package:flutter/foundation.dart';
 
 /// Pure helper utilities for device fingerprint generation.
 ///
 /// All methods are static, pure, and have no side effects,
 /// making them easy to unit test independently.
-@visibleForTesting
 class DeviceFingerprintHelper {
   /// Normalizes device data by sorting entries alphabetically by key.
   ///

--- a/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
@@ -30,6 +30,25 @@ class DeviceFingerprintHelper {
     return hash.toString();
   }
 
+  /// 알려진 불량 SSAID 상수 — 일부 구형 단말이 하드코딩 반환하던 값.
+  static const String _badAndroidId = '9774d56d682e549c';
+  static final RegExp _hexOnly = RegExp(r'^[0-9a-f]+$');
+
+  /// SSAID(Settings.Secure.ANDROID_ID) 를 검증·정규화한다.
+  ///
+  /// 규칙: trim + 소문자화 → 빈값 / 불량상수 / 비-hex / 8자 미만은 무효(null).
+  /// SSAID 는 통상 16자 hex 지만 leading-zero 등으로 짧게 렌더될 수 있어
+  /// 상한은 강제하지 않는다(유효값 over-reject 방지).
+  static String? normalizeAndroidId(String? ssaid) {
+    if (ssaid == null) return null;
+    final v = ssaid.trim().toLowerCase();
+    if (v.isEmpty) return null;
+    if (v == _badAndroidId) return null;
+    if (v.length < 8) return null;
+    if (!_hexOnly.hasMatch(v)) return null;
+    return v;
+  }
+
   /// Extracts relevant Android device properties into a map.
   ///
   /// Accepts individual property values to remain pure (no dependency

--- a/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
@@ -49,6 +49,16 @@ class DeviceFingerprintHelper {
     return v;
   }
 
+  /// device_hash 네임스페이스 prefix — raw SSAID 역산/타시스템 상관 방지.
+  static const String _androidIdNamespace = 'picnic.android_id:';
+
+  /// 정규화된 SSAID 를 네임스페이스와 함께 SHA-256 한 64-hex 문자열 반환.
+  /// 입력은 [normalizeAndroidId] 를 통과한 값이어야 한다.
+  static String hashAndroidId(String normalizedSsaid) {
+    final bytes = utf8.encode('$_androidIdNamespace$normalizedSsaid');
+    return sha256.convert(bytes).toString();
+  }
+
   /// Extracts relevant Android device properties into a map.
   ///
   /// Accepts individual property values to remain pure (no dependency

--- a/picnic_lib/pubspec.yaml
+++ b/picnic_lib/pubspec.yaml
@@ -107,6 +107,7 @@ dependencies:
   googleapis_auth: ^2.0.0
   json_annotation: ^4.9.0
   uuid: ^4.5.1
+  android_id: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
+++ b/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
@@ -266,6 +266,13 @@ void main() {
         expect(DeviceFingerprintHelper.normalizeAndroidId('a1b2'), isNull);
       });
 
+      test('accepts exactly-8-char valid hex (lower boundary)', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('a1b2c3d4'),
+          'a1b2c3d4',
+        );
+      });
+
       test('lowercases and returns a valid 16-hex SSAID', () {
         expect(
           DeviceFingerprintHelper.normalizeAndroidId('ABCDEF0123456789'),

--- a/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
+++ b/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
@@ -281,6 +281,33 @@ void main() {
       });
     });
 
+    group('hashAndroidId', () {
+      test('is deterministic for the same input', () {
+        final a = DeviceFingerprintHelper.hashAndroidId('abcdef0123456789');
+        final b = DeviceFingerprintHelper.hashAndroidId('abcdef0123456789');
+        expect(a, b);
+      });
+
+      test('returns a 64-char lowercase hex string', () {
+        final h = DeviceFingerprintHelper.hashAndroidId('abcdef0123456789');
+        expect(h.length, 64);
+        expect(RegExp(r'^[0-9a-f]{64}$').hasMatch(h), isTrue);
+      });
+
+      test('equals SHA-256 of the namespaced string', () {
+        const id = 'abcdef0123456789';
+        final expected =
+            sha256.convert(utf8.encode('picnic.android_id:$id')).toString();
+        expect(DeviceFingerprintHelper.hashAndroidId(id), expected);
+      });
+
+      test('namespace makes it differ from a raw SHA-256 of the id', () {
+        const id = 'abcdef0123456789';
+        final raw = sha256.convert(utf8.encode(id)).toString();
+        expect(DeviceFingerprintHelper.hashAndroidId(id), isNot(raw));
+      });
+    });
+
     group('end-to-end: build data then hash', () {
       test('Android device data produces consistent hash', () {
         final data = DeviceFingerprintHelper.buildAndroidDeviceData(

--- a/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
+++ b/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
@@ -236,6 +236,51 @@ void main() {
       });
     });
 
+    group('normalizeAndroidId', () {
+      test('returns null for null input', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId(null), isNull);
+      });
+
+      test('returns null for empty / whitespace input', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId(''), isNull);
+        expect(DeviceFingerprintHelper.normalizeAndroidId('   '), isNull);
+      });
+
+      test('returns null for known-bad constant 9774d56d682e549c', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('9774d56d682e549c'),
+          isNull,
+        );
+        // 대문자로 와도 정규화 후 동일하게 거부
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('9774D56D682E549C'),
+          isNull,
+        );
+      });
+
+      test('returns null for non-hex input', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId('xyz123hello'), isNull);
+      });
+
+      test('returns null for too-short input (< 8 chars)', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId('a1b2'), isNull);
+      });
+
+      test('lowercases and returns a valid 16-hex SSAID', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('ABCDEF0123456789'),
+          'abcdef0123456789',
+        );
+      });
+
+      test('trims surrounding whitespace before validating', () {
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('  dca8e4f1b2c3d4e5  '),
+          'dca8e4f1b2c3d4e5',
+        );
+      });
+    });
+
     group('end-to-end: build data then hash', () {
       test('Android device data produces consistent hash', () {
         final data = DeviceFingerprintHelper.buildAndroidDeviceData(


### PR DESCRIPTION
## 배경

Android `device_hash` 가 현재 per-install 랜덤 UUID(secure storage)라 **앱 재설치 시 값이 바뀐다.** anti-abuse 의 device 코호트 신호("한 기기에서 출석/광고한 distinct 계정 수")가 재설치로 우회된다. iOS 는 Keychain 이 재설치를 견뎌 영향 없음 — Android 한정 문제.

(앞선 build-metadata collision 은 PR #44 의 UUID 전환으로 이미 해소됨. 이번은 그 UUID 가 per-install 이라는 후속 약점.)

## 변경

Android `device_hash` 를 **`Settings.Secure.ANDROID_ID`(SSAID) 의 SHA-256** 으로 산출. SSAID 는 재설치·업데이트를 견디고(공장초기화만 리셋) 기종/펌웨어에서 파생되지 않아 collision 이 없다. 무효(에뮬레이터 등)이면 기존 UUID 흐름으로 폴백. **client-only — 서버/DB/edge-fn 무변경.**

- `android_id` 패키지 추가 (`^0.5.1`)
- `DeviceFingerprintHelper.normalizeAndroidId` / `hashAndroidId` (순수, 단위테스트)
- `DeviceFingerprint.getDeviceId()`: Android SSAID 우선(stored UUID 보다), 무효 시 UUID 폴백. 해시는 미저장(재계산해도 동일)
- `@visibleForTesting` 오표기 제거(프로덕션에서 쓰이던 헬퍼)

Spec/Plan: `docs/superpowers/specs/2026-06-08-android-ssaid-device-hash-design.md`, `docs/superpowers/plans/2026-06-08-android-ssaid-device-hash.md`

## 배포 영향 (검토 완료, 무해)

`device_hash` 는 `DeviceManager` 통해 `device_bans`/`devices` 와도 공유 — 전환 시 Android 단말 1회 재등록:
- **device_bans**: 프로덕션 1건(2025-02 휴면) → un-ban 영향 무의미. 장기적으로 ban 이 재설치-견딤됨(개선)
- **devices**: 새 row 1개 추가/옛 행 stale. **기기수 제한 로직 없음** → 강제 로그아웃·한도 없음. 데이터 위생만
- **세션**: Supabase JWT 기반, device_hash 무관 → **로그아웃 없음**
- 멀쩡한 유저 오차단 없음
- anti-abuse cohort 1회 재흩어짐(의도) → attendance 매일이라 1–2일 재형성

⚠️ **`android_id` 는 네이티브 플러그인 → Shorebird 패치 불가, 스토어 릴리스(`picnic-v*`) 필요.**

## Test Plan

- [x] `normalizeAndroidId`/`hashAndroidId` 단위테스트 (46/46 그린)
- [x] 기존 `device_fingerprint_test.dart` 회귀 없음
- [x] `flutter analyze` 깨끗 (잔여 1건은 out-of-scope dead code `_generateFingerprint`)
- [ ] 실기기(Android): 재설치 후 동일 device_hash, 같은기종 다른단말 다른 hash
- [ ] 에뮬레이터: SSAID null → UUID 폴백 크래시 없음