### PR TITLE
fix(device-fingerprint): android_id 플러그인 제거, 네이티브 MethodChannel로 SSAID 조회

### DIFF
--- a/picnic_app/android/app/src/main/kotlin/io/iconcasting/picnic/app/MainActivity.kt
+++ b/picnic_app/android/app/src/main/kotlin/io/iconcasting/picnic/app/MainActivity.kt
@@ -2,9 +2,11 @@ package io.iconcasting.picnic.app
 
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.WindowManager
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
 import java.util.Locale
 import pangle.custom.PangleNativeHandler
@@ -40,6 +42,17 @@ class MainActivity : FlutterActivity() {
         
         // Pincrux 플러그인 등록
         flutterEngine.plugins.add(PincruxPlugin())
+
+        // 기기 식별자(SSAID) 채널 — picnic_lib DeviceFingerprint 에서 호출.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "picnic/device_id")
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getAndroidId" -> result.success(
+                        Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID)
+                    )
+                    else -> result.notImplemented()
+                }
+            }
     }
 
     // 문제가 있는 MediaTek 기기 감지

--- a/picnic_lib/lib/core/utils/device_fingerprint.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint.dart
@@ -1,5 +1,5 @@
-import 'package:android_id/android_id.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:picnic_lib/core/utils/device_fingerprint_helper.dart';
 import 'package:universal_platform/universal_platform.dart';
@@ -12,6 +12,22 @@ class DeviceFingerprint {
   static final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
   static const _uuidGen = Uuid();
 
+  /// 네이티브(MainActivity)에서 Settings.Secure.ANDROID_ID 를 읽는 채널.
+  /// android_id 플러그인이 AGP/flutter-plugin-loader 라이프사이클과 충돌해
+  /// 직접 MethodChannel 로 대체. iOS 엔 핸들러가 없어 호출 자체를 하지 않는다.
+  static const _deviceChannel = MethodChannel('picnic/device_id');
+
+  /// SSAID 조회. 핸들러 미등록(iOS·구버전)·예외 시 null → UUID 폴백.
+  static Future<String?> _readAndroidId() async {
+    try {
+      return await _deviceChannel.invokeMethod<String>('getAndroidId');
+    } on MissingPluginException {
+      return null;
+    } on PlatformException {
+      return null;
+    }
+  }
+
   /// 기기 식별자.
   ///
   /// Android: SSAID(Settings.Secure.ANDROID_ID) 가 유효하면 그 해시를 우선 반환한다.
@@ -22,7 +38,7 @@ class DeviceFingerprint {
   /// iOS: 기존 UUID 흐름(Keychain 이 재설치를 견딤).
   static Future<String> getDeviceId() async {
     if (UniversalPlatform.isAndroid) {
-      final ssaid = await const AndroidId().getId();
+      final ssaid = await _readAndroidId();
       final norm = DeviceFingerprintHelper.normalizeAndroidId(ssaid);
       if (norm != null) {
         return DeviceFingerprintHelper.hashAndroidId(norm);

--- a/picnic_lib/pubspec.yaml
+++ b/picnic_lib/pubspec.yaml
@@ -107,7 +107,6 @@ dependencies:
   googleapis_auth: ^2.0.0
   json_annotation: ^4.9.0
   uuid: ^4.5.1
-  android_id: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 문제 (릴리스 1.2.29 빌드 실패)

`android_id` 0.5.1의 `build.gradle`이 `compileSdk = flutter.compileSdkVersion` 를 쓰는데, 이 프로젝트의 flutter-plugin-loader 셋업에선 **라이브러리(플러그인) 모듈에 `flutter` extension이 전파되지 않아** "unknown property 'flutter'" → AAB 빌드 실패. (로컬 18초 재현으로 확인.)

gradle subprojects/root-ext 워크어라운드는 모두 flutter-plugin-loader 라이프사이클과 충돌("already evaluated") → 접근 자체가 fragile.

## Fix (spec Option B)

문제의 플러그인을 **제거**하고, `Settings.Secure.ANDROID_ID` 를 **MainActivity의 MethodChannel**(`picnic/device_id`)로 직접 읽음.

- `picnic_lib/.../device_fingerprint.dart`: `AndroidId().getId()` → `_deviceChannel.invokeMethod('getAndroidId')`. MissingPlugin/PlatformException → null → UUID 폴백(fail-open).
- `MainActivity.kt`: 채널 핸들러 등록(`getAndroidId` → SSAID).
- `picnic_lib/pubspec.yaml`: `android_id` 제거.

SSAID의 속성(재설치 견딤·collision 없음)은 동일 — 단지 읽는 경로만 플러그인→네이티브 채널로 교체.

## 검증

- [x] **AAB 빌드 성공** (로컬, 92.5MB) — 이전 실패 해소 확인
- [x] `flutter analyze` 깨끗 (잔여는 기존 dead-code `_generateFingerprint` 1건)
- [x] device_fingerprint 단위테스트 46/46 통과
- [ ] 실기기 런타임(채널이 실제 SSAID 반환) — 스토어 빌드/실기기 확인 필요 (fail-open이라 미동작해도 UUID 폴백, 크래시 없음)