### PR TITLE
fix(ad-shortform): 보상광고 무한 로딩 펄스 방어 (init timeout + watchdog + error-on-empty + always-render close)

### DIFF
--- a/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -86,6 +88,26 @@ class AdShortformLogic {
   }) {
     return !finished && remainingSeconds > 0 && remainingSeconds <= 5;
   }
+
+  /// The close (X) button must ALWAYS be rendered so the user can escape even
+  /// when the controller never initializes (infinite-pulse guard). Kept as a
+  /// named helper for explicitness/testability.
+  static bool shouldRenderCloseButton({required bool hasController}) {
+    return true;
+  }
+
+  /// Whether a video-load error dialog should be raised for an empty videoUrl.
+  /// anti-abuse rate-limit returns an empty url with [blocked] = true and pops
+  /// the route itself, so we must NOT raise a duplicate error dialog in that
+  /// case. Any other empty/failed url should surface the error instead of
+  /// silently pulsing forever.
+  static bool shouldErrorOnEmptyVideoUrl({
+    required String videoUrl,
+    required bool blocked,
+  }) {
+    if (videoUrl.isNotEmpty) return false;
+    return !blocked;
+  }
 }
 
 class AdShortformFullscreenPage extends StatefulWidget {
@@ -93,7 +115,14 @@ class AdShortformFullscreenPage extends StatefulWidget {
   final String? ctaUrl;
   final Future<void> Function() onViewComplete;
   final Future<void> Function() onMore;
-  final Future<({String videoUrl, String? ctaUrl})> Function()? loadAd;
+  /// Loads the ad at route-entry time.
+  ///
+  /// [blocked] signals that an anti-abuse rate-limit already popped the route
+  /// and is showing its own dialog; in that case the page must stay silent
+  /// (no duplicate error dialog). Any other empty videoUrl is treated as a
+  /// load failure and surfaces an error instead of pulsing forever.
+  final Future<({String videoUrl, String? ctaUrl, bool blocked})> Function()?
+      loadAd;
 
   const AdShortformFullscreenPage({
     super.key,
@@ -121,11 +150,43 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
   final GlobalKey<LoadingOverlayState> _loadingOverlayKey =
       GlobalKey<LoadingOverlayState>();
 
+  /// Watchdog: if the controller never initializes within this window (server
+  /// failure / network stall anywhere in initialize/setLooping/setVolume/play),
+  /// force a single error+exit so the loader can never pulse forever.
+  static const Duration _watchdogTimeout = Duration(seconds: 20);
+
+  /// Timeout for the underlying [VideoPlayerController.initialize] call, which
+  /// itself has no timeout (cf. pangle_platform.dart's 5s guard).
+  static const Duration _initializeTimeout = Duration(seconds: 15);
+
+  Timer? _watchdog;
+  bool _errorDialogShown = false;
+
   @override
   void initState() {
     super.initState();
     _enterImmersive();
+    _startWatchdog();
     _initializeFlow();
+  }
+
+  /// Starts the single-exit watchdog. Cancelled when the controller is set,
+  /// on dispose, or once an error dialog is shown.
+  void _startWatchdog() {
+    _watchdog?.cancel();
+    _watchdog = Timer(_watchdogTimeout, () {
+      if (!mounted) return;
+      if (_controller != null) return; // controller arrived in time
+      if (_errorDialogShown) return; // error path already handled exit
+      _showVideoLoadErrorDialog(
+        TimeoutException('ad-shortform watchdog: controller never initialized'),
+      );
+    });
+  }
+
+  void _cancelWatchdog() {
+    _watchdog?.cancel();
+    _watchdog = null;
   }
 
   Future<void> _enterImmersive() async {
@@ -138,21 +199,44 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
 
   Future<void> _initializeFlow() async {
     try {
+      // anti-abuse rate-limit 등으로 loadAd 가 빈 url 을 sentinel 로 반환한 경우,
+      // platform 측이 route pop + rate-limited dialog 를 이미 예약했음을 blocked=true
+      // 로 알려준다. 그 외(network/server 실패·예외)는 빈 url 이라도 에러 다이얼로그를
+      // 띄워 무한펄스로 빠지지 않게 한다.
+      var blocked = false;
       if (widget.loadAd != null) {
-        final result = await widget.loadAd!();
-        _resolvedVideoUrl = result.videoUrl;
-        _resolvedCtaUrl = result.ctaUrl;
+        try {
+          final result = await widget.loadAd!();
+          _resolvedVideoUrl = result.videoUrl;
+          _resolvedCtaUrl = result.ctaUrl;
+          blocked = result.blocked;
+        } catch (e) {
+          // loadAd 자체가 throw (anti-abuse 아님) → 에러 다이얼로그 + pop.
+          _showVideoLoadErrorDialog(e);
+          return;
+        }
       } else {
         _resolvedVideoUrl = widget.videoUrl;
         _resolvedCtaUrl = widget.ctaUrl;
       }
-      // anti-abuse rate-limit 등으로 loadAd 가 빈 url 을 sentinel 로 반환한 경우, page
-      // 가 다음 frame 에 pop 되더라도 그 frame 동안 _initPlayer('') 가 실행되며 충돌.
-      // 빈 url 이면 init 시도 자체를 skip — pop 는 platform 측에서 이미 예약됨.
-      if ((_resolvedVideoUrl ?? '').isEmpty) return;
+
+      final resolvedUrl = _resolvedVideoUrl ?? '';
+      if (resolvedUrl.isEmpty) {
+        // blocked(anti-abuse) 면 조용히 종료(platform 이 dialog/pop 담당),
+        // 그 외 빈 url 은 실패로 보고 에러 다이얼로그.
+        if (AdShortformLogic.shouldErrorOnEmptyVideoUrl(
+          videoUrl: resolvedUrl,
+          blocked: blocked,
+        )) {
+          _showVideoLoadErrorDialog(
+            StateError('ad-shortform: empty video_url'),
+          );
+        }
+        return;
+      }
       if (!mounted) return;
       try {
-        await _initPlayer(_resolvedVideoUrl!);
+        await _initPlayer(resolvedUrl);
       } catch (e) {
         _showVideoLoadErrorDialog(e);
         return;
@@ -169,7 +253,9 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
   Future<void> _initPlayer(String videoUrl) async {
     final ctrl = VideoPlayerController.networkUrl(Uri.parse(videoUrl));
     try {
-      await ctrl.initialize();
+      // initialize() 자체엔 타임아웃이 없어 네트워크 stall 시 영구 hang.
+      // TimeoutException 은 아래 generic catch 로 흘러 에러 다이얼로그로 이어진다.
+      await ctrl.initialize().timeout(_initializeTimeout);
     } on PlatformException catch (e) {
       _showVideoLoadErrorDialog(e);
       return;
@@ -184,6 +270,8 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
       await ctrl.setVolume(1.0);
     } catch (_) {}
     ctrl.addListener(_onProgress);
+    // 컨트롤러가 준비됐으니 워치독 해제 — 단일 탈출 경로 유지.
+    _cancelWatchdog();
     setState(() {
       _controller = ctrl;
     });
@@ -200,6 +288,11 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
 
   void _showVideoLoadErrorDialog(dynamic error) {
     if (!mounted) return;
+    // 워치독·initialize 타임아웃·loadAd 예외 등 여러 경로에서 호출될 수 있으므로
+    // 중복 다이얼로그를 막는다.
+    if (_errorDialogShown) return;
+    _errorDialogShown = true;
+    _cancelWatchdog();
     // 권한/보호된 리소스 등으로 재생 실패 시 공통 에러 다이얼로그 표시 후 화면 종료
     void closePage() {
       final c = navigatorKey.currentContext;
@@ -286,7 +379,41 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
     );
   }
 
+  /// The circular close (X) icon. Always rendered so the user is never trapped
+  /// in the loader. [onTap] is null when the close action is intentionally
+  /// disabled (e.g. reward in progress at the end of playback).
+  Widget _buildCloseIcon({required VoidCallback? onTap}) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 24,
+        height: 24,
+        decoration: BoxDecoration(
+          color: AppColors.grey300,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: AppColors.grey500,
+          ),
+        ),
+        child: Icon(
+          Icons.close,
+          color: AppColors.grey500,
+          size: 18,
+        ),
+      ),
+    );
+  }
+
   Future<void> _handleClosePressed() async {
+    // 컨트롤러가 아직 없으면(로딩/실패 중) 재생 중이 아니므로 확인 다이얼로그 없이
+    // 즉시 route pop — 무한펄스에 갇히지 않는 탈출 경로.
+    if (_controller == null) {
+      debugPrint('[internal] close pressed (controller null) -> pop');
+      _cancelWatchdog();
+      if (mounted) Navigator.of(context).maybePop();
+      return;
+    }
+
     final v = _controller?.value;
     final canClose = v != null &&
         AdShortformLogic.canCloseImmediately(
@@ -339,6 +466,7 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
 
   @override
   void dispose() {
+    _cancelWatchdog();
     try {
       _controller?.removeListener(_onProgress);
     } catch (_) {}
@@ -417,12 +545,19 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
                       ),
               ),
 
-              // 닫기 + 카운트다운 (우상단, SafeArea 패딩 수동 적용)
+              // 닫기 + 카운트다운 (우상단, SafeArea 패딩 수동 적용).
+              // 닫기(X) 버튼은 controller 가 null(로딩/실패) 이어도 항상 렌더해
+              // 무한펄스에 갇히지 않게 한다. 카운트다운 뱃지는 controller 가 있을 때만.
               Positioned(
                 top: pad.top - 12,
                 right: 24,
                 child: ctrl == null
-                    ? const SizedBox.shrink()
+                    ? Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _buildCloseIcon(onTap: _handleClosePressed),
+                        ],
+                      )
                     : ValueListenableBuilder(
                         valueListenable: ctrl,
                         builder: (_, _, _) {
@@ -483,26 +618,10 @@ class _AdShortformFullscreenPageState extends State<AdShortformFullscreenPage> {
                                   ),
                                 ),
                               const SizedBox(width: 8),
-                              GestureDetector(
+                              _buildCloseIcon(
                                 onTap: finished
                                     ? (canCloseNow ? _handleClosePressed : null)
                                     : _handleClosePressed,
-                                child: Container(
-                                  width: 24,
-                                  height: 24,
-                                  decoration: BoxDecoration(
-                                    color: AppColors.grey300,
-                                    shape: BoxShape.circle,
-                                    border: Border.all(
-                                      color: AppColors.grey500,
-                                    ),
-                                  ),
-                                  child: Icon(
-                                    Icons.close,
-                                    color: AppColors.grey500,
-                                    size: 18,
-                                  ),
-                                ),
                               ),
                             ],
                           );

--- a/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/platforms/shortform_internal_platform.dart
+++ b/picnic_lib/lib/presentation/widgets/vote/store/free_charge_station/platforms/shortform_internal_platform.dart
@@ -179,8 +179,12 @@ class ShortformInternalPlatform extends AdPlatform {
   }
 
   /// loadAd 경로 — anti-abuse 매핑 + token 추출 책임을 한 군데로 모음.
-  /// blocked 시 fullscreen 라우트를 닫고 부모 context 에서 dialog 노출 후 빈 결과 반환.
-  Future<({String videoUrl, String? ctaUrl})> _issueAdTokensFromRoute() async {
+  /// anti-abuse 차단 시 fullscreen 라우트를 닫고 부모 context 에서 dialog 노출 후
+  /// `blocked: true` 인 빈 결과를 반환한다. 그 외 실패(예: server 오류)는 rethrow 되어
+  /// fullscreen 의 _initializeFlow 가 에러 다이얼로그를 띄운다. blocked 플래그로
+  /// "anti-abuse 가 이미 pop 예약" vs "그냥 실패/빈값" 을 구분해 무한펄스를 막는다.
+  Future<({String videoUrl, String? ctaUrl, bool blocked})>
+      _issueAdTokensFromRoute() async {
     final supabaseUrl = Environment.supabaseUrl;
     final token = supabase.auth.currentSession?.accessToken ?? '';
     // Attach X-Device-Id for anti-abuse device-cohort signal.
@@ -215,15 +219,17 @@ class ShortformInternalPlatform extends AdPlatform {
       logInfo('issued (route) video_url: ${_videoUrl ?? ''}');
       _viewToken = tokens?['view_token'] as String?;
       _moreToken = tokens?['more_token'] as String?;
-      return (videoUrl: _videoUrl ?? '', ctaUrl: _ctaUrl);
+      return (videoUrl: _videoUrl ?? '', ctaUrl: _ctaUrl, blocked: false);
     } catch (e) {
       final aa = mapToAntiAbuseException(e);
       if (aa is AntiAbuseException) {
         logWarning('ad-shortform-issue blocked: channel=${aa.channel}');
         _showRateLimitedAndCloseRoute(aa.channel);
-        // 빈 videoUrl 반환 → fullscreen 의 _initializeFlow 가 mounted 체크에서 종료.
-        return (videoUrl: '', ctaUrl: null);
+        // anti-abuse 차단: route pop + rate-limited dialog 는 여기서 처리됨.
+        // blocked:true 로 fullscreen 이 중복 에러 다이얼로그를 띄우지 않게 한다.
+        return (videoUrl: '', ctaUrl: null, blocked: true);
       }
+      // anti-abuse 가 아닌 실패는 rethrow → fullscreen 이 에러 다이얼로그 + pop.
       rethrow;
     }
   }

--- a/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page_render_test.dart
+++ b/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page_render_test.dart
@@ -87,6 +87,7 @@ void main() {
               return (
                 videoUrl: 'https://example.com/ad.mp4',
                 ctaUrl: 'https://example.com/cta',
+                blocked: false,
               );
             },
           ),

--- a/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page_test.dart
+++ b/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page_test.dart
@@ -23,8 +23,11 @@ void main() {
         ctaUrl: 'https://test.com/cta',
         onViewComplete: () async {},
         onMore: () async {},
-        loadAd: () async =>
-            (videoUrl: 'https://test.com/ad.mp4', ctaUrl: 'https://cta.com'),
+        loadAd: () async => (
+          videoUrl: 'https://test.com/ad.mp4',
+          ctaUrl: 'https://cta.com',
+          blocked: false,
+        ),
       );
 
       expect(widget.videoUrl, 'https://test.com/video.mp4');
@@ -116,8 +119,11 @@ void main() {
         videoUrl: '',
         onViewComplete: () async {},
         onMore: () async {},
-        loadAd: () async =>
-            (videoUrl: 'https://ad.com/v.mp4', ctaUrl: 'https://ad.com/cta'),
+        loadAd: () async => (
+          videoUrl: 'https://ad.com/v.mp4',
+          ctaUrl: 'https://ad.com/cta',
+          blocked: false,
+        ),
       );
 
       final result = await widget.loadAd!();
@@ -131,7 +137,7 @@ void main() {
         onViewComplete: () async {},
         onMore: () async {},
         loadAd: () async =>
-            (videoUrl: 'https://ad.com/v.mp4', ctaUrl: null),
+            (videoUrl: 'https://ad.com/v.mp4', ctaUrl: null, blocked: false),
       );
 
       final result = await widget.loadAd!();

--- a/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_infinite_pulse_guard_test.dart
+++ b/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_infinite_pulse_guard_test.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:picnic_lib/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_fullscreen_page.dart';
+
+import '../../../../../../helpers/ignore_image_errors.dart';
+import '../../../../../../helpers/test_app.dart';
+import '../../../../../../helpers/test_environment.dart';
+
+/// Regression tests for the "infinite loading pulse" defect:
+/// when the video controller never initializes (server failure, empty
+/// video_url, or a network stall), the page must still offer an escape
+/// route and surface an error instead of pulsing forever.
+///
+/// Headless widget tests cannot create a real VideoPlayerController, so the
+/// controller stays `null` for the whole test — which is exactly the stuck
+/// state we want to verify the guards handle.
+void main() {
+  late void Function() restore;
+
+  setUp(() {
+    initTestColors();
+    restore = suppressImageErrors();
+  });
+
+  tearDown(() {
+    restore();
+  });
+
+  /// Pushes the page onto a fresh route so that closing it via Navigator.pop
+  /// is observable through the surviving route count.
+  Future<void> pumpPageInRoute(
+    WidgetTester tester, {
+    required AdShortformFullscreenPage page,
+  }) async {
+    await tester.pumpWidget(
+      buildTestAppPage(
+        Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(builder: (_) => page),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await pumpAndIgnoreErrors(tester);
+    await tester.tap(find.text('open'));
+    await pumpAndIgnoreErrors(tester);
+    await pumpAndIgnoreErrors(tester, const Duration(milliseconds: 300));
+  }
+
+  group('infinite pulse escape — close button always rendered', () {
+    testWidgets(
+        'close (X) button is rendered while controller is null (loadAd never completes)',
+        (WidgetTester tester) async {
+      final completer = Completer<({String videoUrl, String? ctaUrl, bool blocked})>();
+      final page = AdShortformFullscreenPage(
+        videoUrl: '',
+        onViewComplete: () async {},
+        onMore: () async {},
+        loadAd: () => completer.future, // never completes -> controller null
+      );
+
+      await pumpPageInRoute(tester, page: page);
+
+      // The page is on screen but the controller has not initialized.
+      expect(find.byType(AdShortformFullscreenPage), findsOneWidget);
+      // Escape hatch: the close icon must be rendered even with null controller.
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping close while controller is null pops the route (no infinite pulse)',
+        (WidgetTester tester) async {
+      final completer = Completer<({String videoUrl, String? ctaUrl, bool blocked})>();
+      final page = AdShortformFullscreenPage(
+        videoUrl: '',
+        onViewComplete: () async {},
+        onMore: () async {},
+        loadAd: () => completer.future,
+      );
+
+      await pumpPageInRoute(tester, page: page);
+      expect(find.byType(AdShortformFullscreenPage), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      // Let the pop + route exit transition settle. pumpAndSettle would hang on
+      // the infinite pulse animation, so pump fixed frames instead.
+      await pumpAndIgnoreErrors(tester);
+      await pumpAndIgnoreErrors(tester, const Duration(milliseconds: 400));
+      await pumpAndIgnoreErrors(tester, const Duration(milliseconds: 400));
+
+      // Route popped — the user escaped the stuck loader.
+      expect(find.byType(AdShortformFullscreenPage), findsNothing);
+    });
+  });
+
+  group('empty / failed videoUrl surfaces error (not silent infinite pulse)',
+      () {
+    testWidgets(
+        'empty videoUrl with blocked=false shows error dialog and pops route',
+        (WidgetTester tester) async {
+      final page = AdShortformFullscreenPage(
+        videoUrl: '',
+        onViewComplete: () async {},
+        onMore: () async {},
+        loadAd: () async => (videoUrl: '', ctaUrl: null, blocked: false),
+      );
+
+      await pumpPageInRoute(tester, page: page);
+      await pumpAndIgnoreErrors(tester, const Duration(milliseconds: 300));
+
+      // An error dialog is shown rather than pulsing forever.
+      expect(find.byType(Dialog), findsOneWidget);
+      expect(
+        find.text('광고 로드에 실패했습니다. 다시 시도해주세요.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'blocked=true (anti-abuse) does NOT show an error dialog (silent pop)',
+        (WidgetTester tester) async {
+      final page = AdShortformFullscreenPage(
+        videoUrl: '',
+        onViewComplete: () async {},
+        onMore: () async {},
+        loadAd: () async => (videoUrl: '', ctaUrl: null, blocked: true),
+      );
+
+      await pumpPageInRoute(tester, page: page);
+      await pumpAndIgnoreErrors(tester, const Duration(milliseconds: 300));
+
+      // anti-abuse path handles its own rate-limited dialog; the page must not
+      // raise a duplicate video-load error dialog.
+      expect(
+        find.text('광고 로드에 실패했습니다. 다시 시도해주세요.'),
+        findsNothing,
+      );
+    });
+  });
+}

--- a/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_logic_test.dart
+++ b/picnic_lib/test/presentation/widgets/vote/store/free_charge_station/platforms/ad_shortform_logic_test.dart
@@ -406,6 +406,66 @@ void main() {
     });
   });
 
+  group('AdShortformLogic.shouldRenderCloseButton', () {
+    test('renders when controller is null (escape from infinite pulse)', () {
+      expect(
+        AdShortformLogic.shouldRenderCloseButton(hasController: false),
+        isTrue,
+      );
+    });
+
+    test('renders when controller is present', () {
+      expect(
+        AdShortformLogic.shouldRenderCloseButton(hasController: true),
+        isTrue,
+      );
+    });
+  });
+
+  group('AdShortformLogic.shouldErrorOnEmptyVideoUrl', () {
+    test('errors when videoUrl empty and not blocked by anti-abuse', () {
+      expect(
+        AdShortformLogic.shouldErrorOnEmptyVideoUrl(
+          videoUrl: '',
+          blocked: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not error when blocked by anti-abuse (route already popping)',
+        () {
+      expect(
+        AdShortformLogic.shouldErrorOnEmptyVideoUrl(
+          videoUrl: '',
+          blocked: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not error when videoUrl is present', () {
+      expect(
+        AdShortformLogic.shouldErrorOnEmptyVideoUrl(
+          videoUrl: 'https://example.com/v.m3u8',
+          blocked: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not error when videoUrl present even if (impossibly) blocked',
+        () {
+      expect(
+        AdShortformLogic.shouldErrorOnEmptyVideoUrl(
+          videoUrl: 'https://example.com/v.m3u8',
+          blocked: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('AdShortformLogic.shouldShowCountdown', () {
     test('returns true for 1-5 seconds remaining', () {
       for (int i = 1; i <= 5; i++) {


### PR DESCRIPTION
## 배경 (구조적 결함, 회귀 아님 — 2025-10-16부터 상존)

무료충전소 \"글로벌 픽 #1\"(internal-shortform 보상광고) → 풀스크린 `AdShortformFullscreenPage` 가 `loadAd`(ad-shortform-issue) 로 video_url 을 받아 `VideoPlayerController.initialize()`. 서버 실패·빈 video_url·네트워크 stall 이면 **`_controller` 가 영원히 null** 로 남아:

- 로더가 무조건 무한 펄스 (`ctrl == null ? _buildPulseOverlay(true)`),
- 닫기(X) 버튼이 미렌더 (`ctrl == null ? SizedBox.shrink()`) → OS back 외 탈출 불가,
- `initialize()` 에 타임아웃 없음 (대조: `pangle_platform.dart` 는 5s 타임아웃 보유).

서버는 별도 수정됐지만, 어떤 실패에서도 무한펄스가 재발 가능한 클라이언트 측 결함을 방어한다.

## 방어 4가지

### `ad_shortform_fullscreen_page.dart`
1. **initialize() 타임아웃** — `ctrl.initialize().timeout(15s)`. `TimeoutException` 은 기존 generic catch → `_showVideoLoadErrorDialog`. stall 시 영구 hang 방지.
2. **워치독** — `initState` 에서 20s `Timer` 시작. 발화 시 `mounted && _controller == null` 이면 단일 에러+종료 강제. 컨트롤러 set·dispose·에러 다이얼로그 표시 시 cancel. initialize/setLooping/setVolume/play 어디서 hang 하든 단일 탈출 경로 보장.
3. **빈/실패 videoUrl 처리** — `loadAd` 를 try/catch 로 감싸 예외 시 에러 다이얼로그+pop. `blocked=false` 인 빈 url 도 에러 다이얼로그. anti-abuse(`blocked=true`) 는 기존대로 조용히 종료(중복 다이얼로그 방지).
4. **닫기 버튼 상시 렌더** — controller null 이어도 X 버튼 렌더. null 일 때 탭하면 확인 다이얼로그 없이 즉시 route pop. 카운트다운 뱃지는 기존대로 controller 있을 때만.

### `shortform_internal_platform.dart`
- `_issueAdTokensFromRoute` 반환 record 에 `blocked` 플래그 추가. anti-abuse 차단=`blocked:true`(route pop + rate-limited dialog 자체 처리), 그 외 실패=rethrow → fullscreen 이 에러 다이얼로그. 기존 anti-abuse 동작·rate-limited 다이얼로그 유지.

## 테스트 (TDD)

- 순수 헬퍼 유닛: `AdShortformLogic.shouldRenderCloseButton`, `shouldErrorOnEmptyVideoUrl` (blocked 구분).
- 위젯: loadAd 미완료(Completer)면 X 버튼 렌더 + 탭 시 route pop / 빈 url(blocked=false)이면 에러 다이얼로그 / blocked=true 면 다이얼로그 미표시.
- `flutter test test/.../free_charge_station/` → **303 통과** (baseline 293 + 신규 10).
- 헤드리스 제약: 실제 `VideoPlayerController` 를 만들 수 없어 controller-null 분기만 검증 가능. initialize 타임아웃·재생 성공 경로의 실제 비디오 동작은 위젯 테스트로 커버 불가(production 코드의 timeout/watchdog 로직 자체는 들어가 있음).

## 검증

- `flutter analyze` (변경 파일): 신규 이슈 0. 남은 `unnecessary_import` info 2건은 baseline 에 이미 존재(이번 변경 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)