### PR TITLE
fix(device-id): low-entropy/known-bad SSAID guard (collision defense-in-depth)

### DIFF
--- a/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
+++ b/picnic_lib/lib/core/utils/device_fingerprint_helper.dart
@@ -28,22 +28,35 @@ class DeviceFingerprintHelper {
     return hash.toString();
   }
 
-  /// 알려진 불량 SSAID 상수 — 일부 구형 단말이 하드코딩 반환하던 값.
-  static const String _badAndroidId = '9774d56d682e549c';
+  /// 알려진 불량 SSAID 상수 — 일부 단말/에뮬레이터/ROM 이 하드코딩·공유 반환하던 값.
+  /// 이 값들은 서로 다른 물리 기기가 동일하게 반환 → device_hash 충돌(collision) 유발.
+  static const Set<String> _badAndroidIds = {
+    '9774d56d682e549c', // 구형 단말 다수가 공유하던 대표 불량 상수
+    'dead00beef',       // 일부 ROM 디버그 빌드
+    '0123456789abcdef', // placeholder/예시값을 그대로 반환하는 단말
+    '1234567890abcdef',
+  };
   static final RegExp _hexOnly = RegExp(r'^[0-9a-f]+$');
 
   /// SSAID(Settings.Secure.ANDROID_ID) 를 검증·정규화한다.
   ///
-  /// 규칙: trim + 소문자화 → 빈값 / 불량상수 / 비-hex / 8자 미만은 무효(null).
+  /// 규칙: trim + 소문자화 → 빈값 / 불량상수 / 비-hex / 8자 미만 / 저엔트로피는 무효(null).
   /// SSAID 는 통상 16자 hex 지만 leading-zero 등으로 짧게 렌더될 수 있어
   /// 상한은 강제하지 않는다(유효값 over-reject 방지).
+  ///
+  /// 저엔트로피 가드: distinct hex 문자 ≤ 2 (예: 0000…, ffff…, abababab) 는
+  /// 깨진/공유 SSAID 로 보고 거부 → UUID 폴백(설치별 고유, 충돌 없음). 진짜 random
+  /// 64-bit SSAID 가 distinct ≤ 2 일 확률은 천문학적으로 낮아 정상값 over-reject 위험 없음.
+  /// (정상으로 보이는 16-hex 가 기기 배치 단위로 공유되는 케이스는 클라이언트가 알 수
+  ///  없어 못 막는다 — 서버측 IP-분산 게이트가 그 collision 을 비차단 처리한다.)
   static String? normalizeAndroidId(String? ssaid) {
     if (ssaid == null) return null;
     final v = ssaid.trim().toLowerCase();
     if (v.isEmpty) return null;
-    if (v == _badAndroidId) return null;
     if (v.length < 8) return null;
     if (!_hexOnly.hasMatch(v)) return null;
+    if (_badAndroidIds.contains(v)) return null;
+    if (v.split('').toSet().length <= 2) return null; // 저엔트로피(거의 단일문자) 거부
     return v;
   }
 

--- a/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
+++ b/picnic_lib/test/core/utils/device_fingerprint_helper_test.dart
@@ -258,6 +258,47 @@ void main() {
         );
       });
 
+      test('returns null for additional known-bad constants', () {
+        expect(DeviceFingerprintHelper.normalizeAndroidId('dead00beef'), isNull);
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('0123456789abcdef'),
+          isNull,
+        );
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('1234567890abcdef'),
+          isNull,
+        );
+      });
+
+      test('returns null for low-entropy SSAID (<= 2 distinct hex chars)', () {
+        // 에뮬레이터/깨진 ROM 이 반환하는 올-제로 등 — 충돌 유발
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('0000000000000000'),
+          isNull,
+        );
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('ffffffffffffffff'),
+          isNull,
+        );
+        // 2개 문자만 반복하는 패턴도 거부
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('abababababababab'),
+          isNull,
+        );
+      });
+
+      test('accepts SSAID with >= 3 distinct hex chars (entropy ok)', () {
+        // 정상값 over-reject 방지 회귀 가드
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('a1b2c3d4'),
+          'a1b2c3d4',
+        );
+        expect(
+          DeviceFingerprintHelper.normalizeAndroidId('dca8e4f1b2c3d4e5'),
+          'dca8e4f1b2c3d4e5',
+        );
+      });
+
       test('returns null for non-hex input', () {
         expect(DeviceFingerprintHelper.normalizeAndroidId('xyz123hello'), isNull);
       });


### PR DESCRIPTION
## 배경
Android `device_hash` = `hashAndroidId(Settings.Secure.ANDROID_ID)`. 일부 단말/에뮬레이터/ROM 이 ANDROID_ID 를 **비고유**(하드코딩·올제로·공유) 반환 → 서로 다른 물리 기기가 동일 device_hash 충돌 → anti-abuse device 코호트 FP.

## 변경
`normalizeAndroidId` 강화:
- known-bad 상수 목록 확장 (`9774d56d682e549c` 외 ROM/placeholder 값)
- **저엔트로피 가드**: distinct hex 문자 ≤ 2 (예: `0000…`, `ffff…`, `abababab`) 거부 → UUID 폴백(설치별 고유, 충돌 없음). 진짜 random 64-bit SSAID 가 distinct ≤ 2 일 확률은 천문학적으로 낮아 정상값 over-reject 위험 없음.

## 한계 (명시)
정상으로 보이는 16-hex 가 **저가 단말 배치 단위로 공유**되는 collision 은 클라이언트가 판별 불가(혼자선 valid 한 hex). 그 케이스는 서버측 **IP-분산 게이트**(picnic-supabase #58, 적용 완료)가 비차단으로 처리한다. 본 PR 은 교과서적 불량값(에뮬레이터 올-제로 등) 차단 **defense-in-depth**.

## 테스트
helper test 4 케이스 추가 — 추가 상수 거부 / 저엔트로피 거부 / ≥3 distinct 정상 수용(회귀 가드) / 기존. **37/37 통과.**

## 배포
순수 Dart → **Shorebird 패치** 가능(스토어 릴리스 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)